### PR TITLE
Quick wins: bats in CI, PBS integration test (#2), shellcheck autofix (#7)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y shellcheck
 
+    - name: Install bats
+      run: |
+        sudo apt-get install -y bats
+
     - name: Run Bandit (Python Security Scanner)
       run: |
         ./run_bandit.sh
@@ -50,6 +54,11 @@ jobs:
     - name: Run Test Harness
       run: |
         ./test_exports.sh
+      continue-on-error: false
+
+    - name: Run bats Test Suite
+      run: |
+        bats tests/
       continue-on-error: false
 
   snyk-scan:

--- a/anonymize_cluster_data.sh
+++ b/anonymize_cluster_data.sh
@@ -81,7 +81,7 @@ EOF
 }
 
 # Check arguments
-if [ $# -lt 2 ]; then
+if [[ $# -lt 2 ]]; then
     log_error "Missing required arguments"
     usage
 fi
@@ -90,24 +90,24 @@ INPUT_CSV="$1"
 OUTPUT_CSV="$2"
 
 # Validate input file
-if [ ! -f "$INPUT_CSV" ]; then
-    log_error "Input file not found: $INPUT_CSV"
+if [[ ! -f "${INPUT_CSV}" ]]; then
+    log_error "Input file not found: ${INPUT_CSV}"
     exit 1
 fi
 
-if [ ! -r "$INPUT_CSV" ]; then
-    log_error "Input file not readable: $INPUT_CSV"
+if [[ ! -r "${INPUT_CSV}" ]]; then
+    log_error "Input file not readable: ${INPUT_CSV}"
     exit 1
 fi
 
 log_info "Starting anonymization process..."
-log_info "Input file: $INPUT_CSV"
-log_info "Output file: $OUTPUT_CSV"
-log_info "Mapping file: $MAPPING_FILE"
+log_info "Input file: ${INPUT_CSV}"
+log_info "Output file: ${OUTPUT_CSV}"
+log_info "Mapping file: ${MAPPING_FILE}"
 
 # Read CSV header
-HEADER=$(head -n 1 "$INPUT_CSV")
-log_info "Detected columns: $HEADER"
+HEADER=$(head -n 1 "${INPUT_CSV}")
+log_info "Detected columns: ${HEADER}"
 
 # Detect user, group, and hostname columns
 USER_COL=""
@@ -116,51 +116,51 @@ HOSTNAME_COL=""
 ACCOUNT_COL=""
 COL_NUM=1
 
-IFS=',' read -ra COLS <<< "$HEADER"
+IFS=',' read -ra COLS <<< "${HEADER}"
 for col in "${COLS[@]}"; do
-    col_lower=$(echo "$col" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
+    col_lower=$(echo "${col}" | tr '[:upper:]' '[:lower:]' | tr -d ' ')
 
     # Detect user column (prefer 'user' over 'account')
-    if [[ "$col_lower" =~ ^(user|uid|username)$ ]]; then
-        USER_COL="$col"
-        USER_COL_NUM=$COL_NUM
-        log_info "Found user column: '$USER_COL' (position $USER_COL_NUM)"
-    elif [[ "$col_lower" =~ ^(account)$ ]] && [ -z "$USER_COL" ]; then
+    if [[ "${col_lower}" =~ ^(user|uid|username)$ ]]; then
+        USER_COL="${col}"
+        USER_COL_NUM=${COL_NUM}
+        log_info "Found user column: '${USER_COL}' (position ${USER_COL_NUM})"
+    elif [[ "${col_lower}" =~ ^(account)$ ]] && [[ -z "${USER_COL}" ]]; then
         # Only use 'account' if no 'user' column found yet
-        ACCOUNT_COL="$col"
-        ACCOUNT_COL_NUM=$COL_NUM
-        log_info "Found account column: '$ACCOUNT_COL' (position $ACCOUNT_COL_NUM)"
+        ACCOUNT_COL="${col}"
+        ACCOUNT_COL_NUM=${COL_NUM}
+        log_info "Found account column: '${ACCOUNT_COL}' (position ${ACCOUNT_COL_NUM})"
     fi
 
     # Detect group column
-    if [[ "$col_lower" =~ ^(group|gid|groupname)$ ]]; then
-        GROUP_COL="$col"
-        GROUP_COL_NUM=$COL_NUM
-        log_info "Found group column: '$GROUP_COL' (position $GROUP_COL_NUM)"
+    if [[ "${col_lower}" =~ ^(group|gid|groupname)$ ]]; then
+        GROUP_COL="${col}"
+        GROUP_COL_NUM=${COL_NUM}
+        log_info "Found group column: '${GROUP_COL}' (position ${GROUP_COL_NUM})"
     fi
 
     # Detect hostname column
-    if [[ "$col_lower" =~ ^(hostname|nodename|nodelist|host|node)$ ]]; then
-        HOSTNAME_COL="$col"
-        HOSTNAME_COL_NUM=$COL_NUM
-        log_info "Found hostname column: '$HOSTNAME_COL' (position $HOSTNAME_COL_NUM)"
+    if [[ "${col_lower}" =~ ^(hostname|nodename|nodelist|host|node)$ ]]; then
+        HOSTNAME_COL="${col}"
+        HOSTNAME_COL_NUM=${COL_NUM}
+        log_info "Found hostname column: '${HOSTNAME_COL}' (position ${HOSTNAME_COL_NUM})"
     fi
 
     ((COL_NUM++))
 done
 
 # If no explicit 'user' column found, use 'account' as fallback
-if [ -z "$USER_COL" ] && [ -n "$ACCOUNT_COL" ]; then
-    USER_COL="$ACCOUNT_COL"
-    USER_COL_NUM=$ACCOUNT_COL_NUM
+if [[ -z "${USER_COL}" ]] && [[ -n "${ACCOUNT_COL}" ]]; then
+    USER_COL="${ACCOUNT_COL}"
+    USER_COL_NUM=${ACCOUNT_COL_NUM}
     log_info "Using account column as user column (no explicit 'user' column found)"
 fi
 
 # Validate columns found
-if [ -z "$USER_COL" ] && [ -z "$GROUP_COL" ] && [ -z "$HOSTNAME_COL" ]; then
+if [[ -z "${USER_COL}" ]] && [[ -z "${GROUP_COL}" ]] && [[ -z "${HOSTNAME_COL}" ]]; then
     log_error "No user, group, or hostname columns detected in CSV"
     log_error "Expected columns like: user, uid, username, account, group, gid, groupname, hostname, nodename"
-    log_error "Found: $HEADER"
+    log_error "Found: ${HEADER}"
     exit 1
 fi
 
@@ -173,47 +173,47 @@ validate_column_data() {
     local col_type="$3"  # user, group, or hostname
 
     # Sample first 10 data rows (skip header)
-    local sample=$(tail -n +2 "$INPUT_CSV" | head -10 | cut -d',' -f"$col_num" | tr -d '"')
+    local sample=$(tail -n +2 "${INPUT_CSV}" | head -10 | cut -d',' -f"${col_num}" | tr -d '"')
 
     # Count non-empty values
-    local non_empty=$(echo "$sample" | grep -v '^$' | wc -l | tr -d ' ')
+    local non_empty=$(echo "${sample}" | grep -v '^$' | wc -l | tr -d ' ')
 
-    if [ "$non_empty" -eq 0 ]; then
-        log_warn "Column '$col_name' appears to be empty in sample data"
+    if [[ "${non_empty}" -eq 0 ]]; then
+        log_warn "Column '${col_name}' appears to be empty in sample data"
         return 1
     fi
 
     # Validate data patterns based on type
-    case "$col_type" in
+    case "${col_type}" in
         user)
             # Users should be alphanumeric with optional dash, underscore, dot
-            if echo "$sample" | grep -qE '^[a-zA-Z0-9._-]+$'; then
-                log_info "✓ User column '$col_name' data looks valid"
+            if echo "${sample}" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+                log_info "✓ User column '${col_name}' data looks valid"
                 return 0
             else
-                log_warn "⚠ User column '$col_name' contains unexpected characters"
+                log_warn "⚠ User column '${col_name}' contains unexpected characters"
                 log_warn "Sample values:"
-                echo "$sample" | head -3 | sed 's/^/    /' >&2
+                echo "${sample}" | head -3 | sed 's/^/    /' >&2
                 return 1
             fi
             ;;
         group)
             # Groups similar to users
-            if echo "$sample" | grep -qE '^[a-zA-Z0-9._-]+$'; then
-                log_info "✓ Group column '$col_name' data looks valid"
+            if echo "${sample}" | grep -qE '^[a-zA-Z0-9._-]+$'; then
+                log_info "✓ Group column '${col_name}' data looks valid"
                 return 0
             else
-                log_warn "⚠ Group column '$col_name' contains unexpected characters"
+                log_warn "⚠ Group column '${col_name}' contains unexpected characters"
                 return 1
             fi
             ;;
         hostname)
             # Hostnames can have dots, dashes, alphanumeric, and commas (for nodelists)
-            if echo "$sample" | grep -qE '^[a-zA-Z0-9.,:_-]+$'; then
-                log_info "✓ Hostname column '$col_name' data looks valid"
+            if echo "${sample}" | grep -qE '^[a-zA-Z0-9.,:_-]+$'; then
+                log_info "✓ Hostname column '${col_name}' data looks valid"
                 return 0
             else
-                log_warn "⚠ Hostname column '$col_name' contains unexpected characters"
+                log_warn "⚠ Hostname column '${col_name}' contains unexpected characters"
                 return 1
             fi
             ;;
@@ -223,30 +223,30 @@ validate_column_data() {
 # Validate detected columns
 VALIDATION_WARNINGS=0
 
-if [ -n "$USER_COL" ]; then
-    if ! validate_column_data "$USER_COL_NUM" "$USER_COL" "user"; then
+if [[ -n "${USER_COL}" ]]; then
+    if ! validate_column_data "${USER_COL_NUM}" "${USER_COL}" "user"; then
         VALIDATION_WARNINGS=$((VALIDATION_WARNINGS + 1))
     fi
 fi
 
-if [ -n "$GROUP_COL" ]; then
-    if ! validate_column_data "$GROUP_COL_NUM" "$GROUP_COL" "group"; then
+if [[ -n "${GROUP_COL}" ]]; then
+    if ! validate_column_data "${GROUP_COL_NUM}" "${GROUP_COL}" "group"; then
         VALIDATION_WARNINGS=$((VALIDATION_WARNINGS + 1))
     fi
 fi
 
-if [ -n "$HOSTNAME_COL" ]; then
-    if ! validate_column_data "$HOSTNAME_COL_NUM" "$HOSTNAME_COL" "hostname"; then
+if [[ -n "${HOSTNAME_COL}" ]]; then
+    if ! validate_column_data "${HOSTNAME_COL_NUM}" "${HOSTNAME_COL}" "hostname"; then
         VALIDATION_WARNINGS=$((VALIDATION_WARNINGS + 1))
     fi
 fi
 
 # Ask user to confirm if warnings found
-if [ $VALIDATION_WARNINGS -gt 0 ]; then
-    log_warn "Found $VALIDATION_WARNINGS validation warnings"
+if [[ "${VALIDATION_WARNINGS}" -gt 0 ]]; then
+    log_warn "Found ${VALIDATION_WARNINGS} validation warnings"
     echo ""
     read -p "Continue with anonymization anyway? (yes/no): " confirm
-    if [[ "$confirm" != "yes" ]]; then
+    if [[ "${confirm}" != "yes" ]]; then
         log_error "Anonymization cancelled by user due to validation warnings"
         exit 1
     fi
@@ -256,82 +256,82 @@ fi
 # Extract unique users, groups, and hostnames
 log_info "Extracting unique users, groups, and hostnames..."
 
-if [ -n "$USER_COL" ]; then
-    tail -n +2 "$INPUT_CSV" | cut -d',' -f"$USER_COL_NUM" | sort -u > "$TEMP_DIR/users.txt"
-    NUM_USERS=$(wc -l < "$TEMP_DIR/users.txt")
-    log_info "Found $NUM_USERS unique users"
+if [[ -n "${USER_COL}" ]]; then
+    tail -n +2 "${INPUT_CSV}" | cut -d',' -f"${USER_COL_NUM}" | sort -u > "${TEMP_DIR}/users.txt"
+    NUM_USERS=$(wc -l < "${TEMP_DIR}/users.txt")
+    log_info "Found ${NUM_USERS} unique users"
 fi
 
-if [ -n "$GROUP_COL" ]; then
-    tail -n +2 "$INPUT_CSV" | cut -d',' -f"$GROUP_COL_NUM" | sort -u > "$TEMP_DIR/groups.txt"
-    NUM_GROUPS=$(wc -l < "$TEMP_DIR/groups.txt")
-    log_info "Found $NUM_GROUPS unique groups"
+if [[ -n "${GROUP_COL}" ]]; then
+    tail -n +2 "${INPUT_CSV}" | cut -d',' -f"${GROUP_COL_NUM}" | sort -u > "${TEMP_DIR}/groups.txt"
+    NUM_GROUPS=$(wc -l < "${TEMP_DIR}/groups.txt")
+    log_info "Found ${NUM_GROUPS} unique groups"
 fi
 
-if [ -n "$HOSTNAME_COL" ]; then
-    tail -n +2 "$INPUT_CSV" | cut -d',' -f"$HOSTNAME_COL_NUM" | sort -u > "$TEMP_DIR/hostnames.txt"
-    NUM_HOSTNAMES=$(wc -l < "$TEMP_DIR/hostnames.txt")
-    log_info "Found $NUM_HOSTNAMES unique hostnames"
+if [[ -n "${HOSTNAME_COL}" ]]; then
+    tail -n +2 "${INPUT_CSV}" | cut -d',' -f"${HOSTNAME_COL_NUM}" | sort -u > "${TEMP_DIR}/hostnames.txt"
+    NUM_HOSTNAMES=$(wc -l < "${TEMP_DIR}/hostnames.txt")
+    log_info "Found ${NUM_HOSTNAMES} unique hostnames"
 fi
 
 # Generate mapping files
 log_info "Generating anonymous mappings..."
 
 # User mapping
-if [ -n "$USER_COL" ]; then
+if [[ -n "${USER_COL}" ]]; then
     counter=1
     while IFS= read -r user; do
         # Skip empty lines
-        [ -z "$user" ] && continue
+        [[ -z "${user}" ]] && continue
 
         # Generate anonymous ID with zero-padding
-        anon_id=$(printf "user_%04d" $counter)
-        echo "$user -> $anon_id"
+        anon_id=$(printf "user_%04d" "${counter}")
+        echo "${user} -> ${anon_id}"
 
         # Store mapping
-        echo "USER: $user -> $anon_id" >> "$TEMP_DIR/mapping.txt"
+        echo "USER: ${user} -> ${anon_id}" >> "${TEMP_DIR}/mapping.txt"
 
         # Store for sed replacement
-        echo "s|^\\([^,]*,\\)\\{$((USER_COL_NUM-1))\\}\\K$user|$anon_id|g" >> "$TEMP_DIR/sed_users.txt"
+        echo "s|^\\([^,]*,\\)\\{$((USER_COL_NUM-1))\\}\\K${user}|${anon_id}|g" >> "${TEMP_DIR}/sed_users.txt"
 
         ((counter++))
-    done < "$TEMP_DIR/users.txt"
+    done < "${TEMP_DIR}/users.txt"
     log_info "Created $((counter-1)) user mappings"
 fi
 
 # Group mapping (using letters)
-if [ -n "$GROUP_COL" ]; then
+if [[ -n "${GROUP_COL}" ]]; then
     counter=1
     while IFS= read -r group; do
         # Skip empty lines
-        [ -z "$group" ] && continue
+        [[ -z "${group}" ]] && continue
 
         # Generate anonymous ID (group_A, group_B, etc.)
         # For >26 groups, use group_AA, group_AB, etc.
-        if [ $counter -le 26 ]; then
+        if [[ "${counter}" -le 26 ]]; then
             letter=$(printf "\\$(printf '%03o' $((64+counter)))")
             anon_id="group_${letter}"
         else
             idx=$((counter-27))
             first=$((idx/26 + 65))
             second=$((idx%26 + 65))
-            anon_id="group_$(printf "\\$(printf '%03o' $first)")$(printf "\\$(printf '%03o' $second)")"
+            anon_id="group_$(printf "\\$(printf '%03o' "${first}")")$(printf "\\$(printf '%03o' "${second}")")"
         fi
 
-        echo "$group -> $anon_id"
+        echo "${group} -> ${anon_id}"
 
         # Store mapping
-        echo "GROUP: $group -> $anon_id" >> "$TEMP_DIR/mapping.txt"
+        echo "GROUP: ${group} -> ${anon_id}" >> "${TEMP_DIR}/mapping.txt"
 
         ((counter++))
-    done < "$TEMP_DIR/groups.txt"
+    done < "${TEMP_DIR}/groups.txt"
     log_info "Created $((counter-1)) group mappings"
 fi
 
 # Create a more robust Python script for anonymization
 log_info "Creating anonymization processor..."
 
-cat > "$TEMP_DIR/anonymize.py" << 'PYTHON_EOF'
+cat > "${TEMP_DIR}/anonymize.py" << 'PYTHON_EOF'
 #!/usr/bin/env python3
 import sys
 import csv
@@ -453,7 +453,7 @@ if __name__ == "__main__":
 
 PYTHON_EOF
 
-chmod +x "$TEMP_DIR/anonymize.py"
+chmod +x "${TEMP_DIR}/anonymize.py"
 
 # Run anonymization
 log_info "Processing CSV file..."
@@ -462,27 +462,27 @@ USER_ARG="${USER_COL_NUM:-None}"
 GROUP_ARG="${GROUP_COL_NUM:-None}"
 HOSTNAME_ARG="${HOSTNAME_COL_NUM:-None}"
 
-python3 "$TEMP_DIR/anonymize.py" "$INPUT_CSV" "$OUTPUT_CSV" "$MAPPING_FILE" "$USER_ARG" "$GROUP_ARG" "$HOSTNAME_ARG"
+python3 "${TEMP_DIR}/anonymize.py" "${INPUT_CSV}" "${OUTPUT_CSV}" "${MAPPING_FILE}" "${USER_ARG}" "${GROUP_ARG}" "${HOSTNAME_ARG}"
 
 # Set secure permissions on mapping file
-chmod 600 "$MAPPING_FILE"
+chmod 600 "${MAPPING_FILE}"
 log_info "Mapping file created with restricted permissions (600)"
 
 # Print summary
 log_info "Anonymization complete!"
 echo ""
 log_info "Summary:"
-log_info "  Input rows: $(tail -n +2 "$INPUT_CSV" | wc -l)"
-log_info "  Output rows: $(tail -n +2 "$OUTPUT_CSV" | wc -l)"
-log_info "  Output file: $OUTPUT_CSV"
-log_info "  Mapping file: $MAPPING_FILE"
+log_info "  Input rows: $(tail -n +2 "${INPUT_CSV}" | wc -l)"
+log_info "  Output rows: $(tail -n +2 "${OUTPUT_CSV}" | wc -l)"
+log_info "  Output file: ${OUTPUT_CSV}"
+log_info "  Mapping file: ${MAPPING_FILE}"
 
 echo ""
 log_warn "SECURITY REMINDER:"
-log_warn "  1. The mapping file ($MAPPING_FILE) allows de-anonymization"
-log_warn "  2. Restrict access to admin-only: chmod 600 $MAPPING_FILE"
+log_warn "  1. The mapping file (${MAPPING_FILE}) allows de-anonymization"
+log_warn "  2. Restrict access to admin-only: chmod 600 ${MAPPING_FILE}"
 log_warn "  3. Store in secure location with limited access"
-log_warn "  4. Consider encrypting: gpg -c $MAPPING_FILE"
+log_warn "  4. Consider encrypting: gpg -c ${MAPPING_FILE}"
 log_warn "  5. Do NOT share mapping file with anonymized data"
 
 echo ""
@@ -492,6 +492,6 @@ log_info "Users and groups are consistently mapped, preserving patterns."
 # Show sample
 echo ""
 log_info "Sample of anonymized data (first 5 rows):"
-head -n 6 "$OUTPUT_CSV"
+head -n 6 "${OUTPUT_CSV}"
 
 exit 0

--- a/export_cluster_configs_all.sh
+++ b/export_cluster_configs_all.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 OUTPUT_DIR="cluster_configs_$(date +%Y%m%d)"
-mkdir -p "$OUTPUT_DIR"
+mkdir -p "${OUTPUT_DIR}"
 
 echo "================================"
 echo "CLUSTER CONFIGURATION EXPORT"
@@ -25,12 +25,12 @@ if command -v sinfo &> /dev/null; then
     echo "✓ Found SLURM"
     FOUND_SCHEDULER=true
 
-    sinfo -N -o "%N,%c,%m,%G,%P,%T,%C" --noheader > "$OUTPUT_DIR/slurm_nodes.tmp"
-    echo "NodeName,CPUs,Memory,Gres,Partition,State,CPUAllocation" > "$OUTPUT_DIR/slurm_config.csv"
-    cat "$OUTPUT_DIR/slurm_nodes.tmp" >> "$OUTPUT_DIR/slurm_config.csv"
-    rm "$OUTPUT_DIR/slurm_nodes.tmp"
+    sinfo -N -o "%N,%c,%m,%G,%P,%T,%C" --noheader > "${OUTPUT_DIR}/slurm_nodes.tmp"
+    echo "NodeName,CPUs,Memory,Gres,Partition,State,CPUAllocation" > "${OUTPUT_DIR}/slurm_config.csv"
+    cat "${OUTPUT_DIR}/slurm_nodes.tmp" >> "${OUTPUT_DIR}/slurm_config.csv"
+    rm "${OUTPUT_DIR}/slurm_nodes.tmp"
 
-    echo "  Exported: $OUTPUT_DIR/slurm_config.csv"
+    echo "  Exported: ${OUTPUT_DIR}/slurm_config.csv"
 fi
 
 # ==============================================================================
@@ -41,7 +41,7 @@ if command -v qhost &> /dev/null; then
     FOUND_SCHEDULER=true
 
     # qhost shows all execution hosts
-    qhost -F -xml > "$OUTPUT_DIR/uge_hosts.xml"
+    qhost -F -xml > "${OUTPUT_DIR}/uge_hosts.xml"
 
     # Parse XML to CSV
     python3 << 'PYTHON_EOF'
@@ -79,8 +79,8 @@ with open(sys.argv[2], 'w', newline='') as f:
 print(f"Exported {len(hosts)} hosts", file=sys.stderr)
 PYTHON_EOF
 
-    python3 - "$OUTPUT_DIR/uge_hosts.xml" "$OUTPUT_DIR/uge_config.csv"
-    echo "  Exported: $OUTPUT_DIR/uge_config.csv"
+    python3 - "${OUTPUT_DIR}/uge_hosts.xml" "${OUTPUT_DIR}/uge_config.csv"
+    echo "  Exported: ${OUTPUT_DIR}/uge_config.csv"
 fi
 
 # ==============================================================================
@@ -91,7 +91,7 @@ if command -v pbsnodes &> /dev/null; then
     FOUND_SCHEDULER=true
 
     # pbsnodes -a shows all nodes
-    pbsnodes -a > "$OUTPUT_DIR/pbs_nodes.txt"
+    pbsnodes -a > "${OUTPUT_DIR}/pbs_nodes.txt"
 
     # Parse pbsnodes output to CSV
     python3 << 'PYTHON_EOF'
@@ -141,8 +141,8 @@ with open(sys.argv[2], 'w', newline='') as f:
 print(f"Exported {len(nodes)} nodes", file=sys.stderr)
 PYTHON_EOF
 
-    python3 - "$OUTPUT_DIR/pbs_nodes.txt" "$OUTPUT_DIR/pbs_config.csv"
-    echo "  Exported: $OUTPUT_DIR/pbs_config.csv"
+    python3 - "${OUTPUT_DIR}/pbs_nodes.txt" "${OUTPUT_DIR}/pbs_config.csv"
+    echo "  Exported: ${OUTPUT_DIR}/pbs_config.csv"
 fi
 
 # ==============================================================================
@@ -153,11 +153,11 @@ if command -v bhosts &> /dev/null; then
     FOUND_SCHEDULER=true
 
     # bhosts -l gives detailed info
-    bhosts -w > "$OUTPUT_DIR/lsf_hosts.txt"
+    bhosts -w > "${OUTPUT_DIR}/lsf_hosts.txt"
 
     # Also get lshosts for hardware info
     if command -v lshosts &> /dev/null; then
-        lshosts -w > "$OUTPUT_DIR/lsf_lshosts.txt"
+        lshosts -w > "${OUTPUT_DIR}/lsf_lshosts.txt"
     fi
 
     # Parse bhosts output
@@ -192,8 +192,8 @@ with open(sys.argv[2], 'w', newline='') as f:
 print(f"Exported {len(hosts)} hosts", file=sys.stderr)
 PYTHON_EOF
 
-    python3 - "$OUTPUT_DIR/lsf_hosts.txt" "$OUTPUT_DIR/lsf_config.csv"
-    echo "  Exported: $OUTPUT_DIR/lsf_config.csv"
+    python3 - "${OUTPUT_DIR}/lsf_hosts.txt" "${OUTPUT_DIR}/lsf_config.csv"
+    echo "  Exported: ${OUTPUT_DIR}/lsf_config.csv"
 fi
 
 # ==============================================================================
@@ -204,20 +204,20 @@ if command -v condor_status &> /dev/null; then
     FOUND_SCHEDULER=true
 
     # condor_status shows all slots
-    condor_status -af:ht Machine Cpus Memory TotalSlots State Activity > "$OUTPUT_DIR/condor_status.tmp"
+    condor_status -af:ht Machine Cpus Memory TotalSlots State Activity > "${OUTPUT_DIR}/condor_status.tmp"
 
-    echo "Machine,Cpus,Memory,TotalSlots,State,Activity" > "$OUTPUT_DIR/htcondor_config.csv"
-    cat "$OUTPUT_DIR/condor_status.tmp" >> "$OUTPUT_DIR/htcondor_config.csv"
-    rm "$OUTPUT_DIR/condor_status.tmp"
+    echo "Machine,Cpus,Memory,TotalSlots,State,Activity" > "${OUTPUT_DIR}/htcondor_config.csv"
+    cat "${OUTPUT_DIR}/condor_status.tmp" >> "${OUTPUT_DIR}/htcondor_config.csv"
+    rm "${OUTPUT_DIR}/condor_status.tmp"
 
-    echo "  Exported: $OUTPUT_DIR/htcondor_config.csv"
+    echo "  Exported: ${OUTPUT_DIR}/htcondor_config.csv"
 fi
 
 # ==============================================================================
 # SUMMARY
 # ==============================================================================
 echo ""
-if [ "$FOUND_SCHEDULER" = false ]; then
+if [[ "${FOUND_SCHEDULER}" = false ]]; then
     echo "ERROR: No supported scheduler found!"
     echo ""
     echo "Supported schedulers:"
@@ -233,14 +233,14 @@ echo "================================"
 echo "CONFIGURATION EXPORT COMPLETE"
 echo "================================"
 echo ""
-echo "Configuration files saved in: $OUTPUT_DIR/"
+echo "Configuration files saved in: ${OUTPUT_DIR}/"
 echo ""
 echo "Next steps:"
 echo "  1. Review configuration files:"
-echo "     ls -lh $OUTPUT_DIR/"
+echo "     ls -lh ${OUTPUT_DIR}/"
 echo ""
 echo "  2. Calculate cluster statistics:"
-echo "     ./analyze_cluster_config.sh $OUTPUT_DIR/*.csv"
+echo "     ./analyze_cluster_config.sh ${OUTPUT_DIR}/*.csv"
 echo ""
 echo "  3. Compare with job utilization data to determine true utilization"
 echo ""

--- a/export_htcondor_data.sh
+++ b/export_htcondor_data.sh
@@ -11,8 +11,8 @@ DAYS_AGO="${1:-365}"  # How many days back to query
 OUTPUT_FILE="htcondor_jobs_with_users_$(date +%Y%m%d).csv"
 
 echo "Exporting HTCondor job data with user/group information..."
-echo "Querying last $DAYS_AGO days"
-echo "Output file: $OUTPUT_FILE"
+echo "Querying last ${DAYS_AGO} days"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if condor_history is available
@@ -22,7 +22,7 @@ if ! command -v condor_history &> /dev/null; then
 fi
 
 CONDOR_VERSION=$(condor_version 2>/dev/null | awk '/CondorVersion/{print $2}' || echo "unknown")
-echo "Detected HTCondor version: $CONDOR_VERSION"
+echo "Detected HTCondor version: ${CONDOR_VERSION}"
 echo "Querying HTCondor history (this may take several minutes)..."
 
 # Use condor_history to export job history
@@ -36,7 +36,7 @@ trap 'rm -f "$TEMP_FILE"' EXIT
 # -constraint 'JobStatus == 4' means completed jobs
 # Add -file option if using file-based history
 
-condor_history -constraint "CompletionDate > (time() - ($DAYS_AGO * 86400))" \
+condor_history -constraint "CompletionDate > (time() - (${DAYS_AGO} * 86400))" \
     -af:ht \
     Owner \
     AcctGroup \
@@ -60,20 +60,20 @@ condor_history -constraint "CompletionDate > (time() - ($DAYS_AGO * 86400))" \
     RemoteWallClockTime \
     CumulativeRemoteSysCpu \
     CumulativeRemoteUserCpu \
-    > "$TEMP_FILE"
+    > "${TEMP_FILE}"
 
-if [ "${VERBOSE:-0}" = "1" ]; then
+if [[ "${VERBOSE:-0}" = "1" ]]; then
     echo "================================================================" >&2
     echo "VERBOSE: Raw condor_history output (first 5 lines):" >&2
-    head -5 "$TEMP_FILE" >&2
-    echo "  ... ($(wc -l < "$TEMP_FILE") total lines)" >&2
+    head -5 "${TEMP_FILE}" >&2
+    echo "  ... ($(wc -l < "${TEMP_FILE}") total lines)" >&2
     echo "================================================================" >&2
 fi
 
 echo "Parsing HTCondor output into CSV format..."
 
 # Parse condor_history output into CSV
-python3 - "$TEMP_FILE" "$OUTPUT_FILE" "htcondor" "$CONDOR_VERSION" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${OUTPUT_FILE}" "htcondor" "${CONDOR_VERSION}" << 'PYTHON_EOF'
 import sys
 import csv
 from datetime import datetime
@@ -287,15 +287,15 @@ echo ""
 echo "Export complete!"
 echo ""
 echo "Statistics:"
-echo "  Total records: $(tail -n +2 "$OUTPUT_FILE" | wc -l)"
-echo "  Output file: $OUTPUT_FILE"
+echo "  Total records: $(tail -n +2 "${OUTPUT_FILE}" | wc -l)"
+echo "  Output file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo "  1. Verify the export:"
-echo "     head $OUTPUT_FILE"
+echo "     head ${OUTPUT_FILE}"
 echo ""
 echo "  2. Run anonymization:"
-echo "     ./anonymize_cluster_data.sh $OUTPUT_FILE htcondor_jobs_anonymized.csv mapping_secure.txt"
+echo "     ./anonymize_cluster_data.sh ${OUTPUT_FILE} htcondor_jobs_anonymized.csv mapping_secure.txt"
 echo ""
 echo "  3. Secure the mapping file:"
 echo "     chmod 600 mapping_secure.txt"

--- a/export_lsf_cluster_config.sh
+++ b/export_lsf_cluster_config.sh
@@ -13,7 +13,7 @@ echo "================================================================"
 echo "LSF Cluster Configuration Export"
 echo "================================================================"
 echo ""
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if LSF commands are available
@@ -39,12 +39,12 @@ echo ""
 
 # Get bhosts output (host status and load)
 echo "Running: bhosts -w"
-bhosts -w > "$TEMP_BHOSTS"
+bhosts -w > "${TEMP_BHOSTS}"
 
 # Get lshosts output (hardware details) if available
 if command -v lshosts &> /dev/null; then
     echo "Running: lshosts -w"
-    lshosts -w > "$TEMP_LSHOSTS"
+    lshosts -w > "${TEMP_LSHOSTS}"
 fi
 
 # Get detailed host info with bhosts -l for resource info
@@ -52,13 +52,13 @@ TEMP_BHOSTS_DETAIL=$(mktemp)
 trap 'rm -f "$TEMP_BHOSTS" "$TEMP_LSHOSTS" "$TEMP_BHOSTS_DETAIL"' EXIT
 
 echo "Running: bhosts -l (detailed host info)"
-bhosts -l > "$TEMP_BHOSTS_DETAIL"
+bhosts -l > "${TEMP_BHOSTS_DETAIL}"
 
 echo ""
 echo "Parsing LSF host data into CSV format..."
 
 # Parse LSF output into CSV
-python3 - "$TEMP_BHOSTS" "$TEMP_LSHOSTS" "$TEMP_BHOSTS_DETAIL" "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${TEMP_BHOSTS}" "${TEMP_LSHOSTS}" "${TEMP_BHOSTS_DETAIL}" "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -224,7 +224,7 @@ echo "LSF CLUSTER CONFIGURATION SUMMARY"
 echo "================================================================"
 
 # Calculate summary statistics
-python3 - "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import csv
 import sys
 
@@ -295,15 +295,15 @@ echo "================================================================"
 echo "EXPORT COMPLETE"
 echo "================================================================"
 echo ""
-echo "Configuration file: $OUTPUT_FILE"
+echo "Configuration file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo ""
 echo "1. Review the configuration:"
-echo "   head -20 $OUTPUT_FILE"
+echo "   head -20 ${OUTPUT_FILE}"
 echo ""
 echo "2. Standardize format (for cross-scheduler comparison):"
-echo "   python3 standardize_cluster_config.py $OUTPUT_FILE"
+echo "   python3 standardize_cluster_config.py ${OUTPUT_FILE}"
 echo ""
 echo "3. Compare with job data to calculate utilization:"
 echo "   # Export job data first:"

--- a/export_lsf_comprehensive.sh
+++ b/export_lsf_comprehensive.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 
 # Load security libraries
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/validation.sh"
-source "$SCRIPT_DIR/security_logging.sh"
+source "${SCRIPT_DIR}/validation.sh"
+source "${SCRIPT_DIR}/security_logging.sh"
 
 # Configuration
 START_DATE="${1:-$(date -d '1 year ago' '+%Y/%m/%d' 2>/dev/null || date -v-1y '+%Y/%m/%d')}"
@@ -19,15 +19,15 @@ END_DATE="${2:-$(date '+%Y/%m/%d')}"
 OUTPUT_FILE="lsf_jobs_with_users_$(date +%Y%m%d).csv"
 
 # Validate and sanitize date inputs
-if ! START_DATE=$(validate_and_sanitize_date "$START_DATE" "lsf"); then
-    log_validation_failure "date" "$START_DATE"
+if ! START_DATE=$(validate_and_sanitize_date "${START_DATE}" "lsf"); then
+    log_validation_failure "date" "${START_DATE}"
     echo "ERROR: Invalid start date format" >&2
     echo "Expected: YYYY/MM/DD (e.g., 2024/01/31)" >&2
     exit 1
 fi
 
-if ! END_DATE=$(validate_and_sanitize_date "$END_DATE" "lsf"); then
-    log_validation_failure "date" "$END_DATE"
+if ! END_DATE=$(validate_and_sanitize_date "${END_DATE}" "lsf"); then
+    log_validation_failure "date" "${END_DATE}"
     echo "ERROR: Invalid end date format" >&2
     echo "Expected: YYYY/MM/DD (e.g., 2024/12/31)" >&2
     exit 1
@@ -37,12 +37,12 @@ echo "================================================================"
 echo "LSF Comprehensive Job Data Export"
 echo "================================================================"
 echo ""
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Log export start
-log_export_start "LSF" "start=$START_DATE end=$END_DATE output=$OUTPUT_FILE"
+log_export_start "LSF" "start=${START_DATE} end=${END_DATE} output=${OUTPUT_FILE}"
 
 # Detect LSF version for metadata column
 LSF_VERSION=$(lsid 2>/dev/null | awk '/IBM Spectrum LSF|Platform LSF/{print $NF; exit}' || \
@@ -76,24 +76,24 @@ trap 'rm -f "$TEMP_FILE" "$BACCT_FILE"' EXIT
 # -C specifies time range
 # -a includes all users (requires LSF admin privileges)
 echo "Running bhist query..."
-bhist -C "$START_DATE,${END_DATE}" -l -a > "$TEMP_FILE" 2>&1 || {
+bhist -C "${START_DATE},${END_DATE}" -l -a > "${TEMP_FILE}" 2>&1 || {
     echo "Warning: bhist -a failed (may need admin privileges)"
     echo "Trying without -a (only your jobs)..."
-    bhist -C "$START_DATE,${END_DATE}" -l > "$TEMP_FILE"
+    bhist -C "${START_DATE},${END_DATE}" -l > "${TEMP_FILE}"
 }
 
-if [ "${VERBOSE:-0}" = "1" ]; then
+if [[ "${VERBOSE:-0}" = "1" ]]; then
     echo "================================================================" >&2
     echo "VERBOSE: Raw bhist output (first 20 lines):" >&2
-    head -20 "$TEMP_FILE" >&2
-    echo "  ... ($(wc -l < "$TEMP_FILE") total lines)" >&2
+    head -20 "${TEMP_FILE}" >&2
+    echo "  ... ($(wc -l < "${TEMP_FILE}") total lines)" >&2
     echo "================================================================" >&2
 fi
 
 # If bacct is available, also query it for more detailed resource usage
-if [ "$HAVE_BACCT" = true ]; then
+if [[ "${HAVE_BACCT}" = true ]]; then
     echo "Running bacct query for resource usage..."
-    bacct -C "$START_DATE,${END_DATE}" -l > "$BACCT_FILE" 2>&1 || {
+    bacct -C "${START_DATE},${END_DATE}" -l > "${BACCT_FILE}" 2>&1 || {
         echo "Warning: bacct query failed, will use bhist data only"
         HAVE_BACCT=false
     }
@@ -103,7 +103,7 @@ echo ""
 echo "Parsing LSF output into standardized CSV format..."
 
 # Parse bhist output into CSV
-python3 - "$TEMP_FILE" "$BACCT_FILE" "$OUTPUT_FILE" "$HAVE_BACCT" "lsf" "$LSF_VERSION" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${BACCT_FILE}" "${OUTPUT_FILE}" "${HAVE_BACCT}" "lsf" "${LSF_VERSION}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -447,29 +447,29 @@ echo "================================================================"
 echo "EXPORT COMPLETE"
 echo "================================================================"
 echo ""
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 echo "File details:"
-ls -lh "$OUTPUT_FILE"
+ls -lh "${OUTPUT_FILE}"
 echo ""
 echo "First few records:"
-head -5 "$OUTPUT_FILE"
+head -5 "${OUTPUT_FILE}"
 echo ""
 echo "================================================================"
 echo "NEXT STEPS"
 echo "================================================================"
 echo ""
 echo "1. Verify the export looks correct:"
-echo "   head -20 $OUTPUT_FILE"
-echo "   tail -20 $OUTPUT_FILE"
+echo "   head -20 ${OUTPUT_FILE}"
+echo "   tail -20 ${OUTPUT_FILE}"
 echo ""
 echo "2. Check statistics:"
-echo "   wc -l $OUTPUT_FILE"
-echo "   cut -d, -f1 $OUTPUT_FILE | sort -u | wc -l  # Unique users"
+echo "   wc -l ${OUTPUT_FILE}"
+echo "   cut -d, -f1 ${OUTPUT_FILE} | sort -u | wc -l  # Unique users"
 echo ""
 echo "3. Anonymize the data:"
 echo "   ./anonymize_cluster_data.sh \\"
-echo "     $OUTPUT_FILE \\"
+echo "     ${OUTPUT_FILE} \\"
 echo "     lsf_jobs_anonymized.csv \\"
 echo "     lsf_mapping_secure.txt"
 echo ""

--- a/export_lsf_data.sh
+++ b/export_lsf_data.sh
@@ -12,8 +12,8 @@ END_DATE="${2:-$(date '+%Y/%m/%d')}"
 OUTPUT_FILE="lsf_jobs_with_users_$(date +%Y%m%d).csv"
 
 echo "Exporting LSF job data with user/group information..."
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if bhist is available
@@ -33,12 +33,12 @@ trap 'rm -f "$TEMP_FILE"' EXIT
 
 # Export with bhist
 # Note: bhist -l gives detailed output that we'll parse
-bhist -C "$START_DATE,${END_DATE}" -l -a > "$TEMP_FILE"
+bhist -C "${START_DATE},${END_DATE}" -l -a > "${TEMP_FILE}"
 
 echo "Parsing LSF output into CSV format..."
 
 # Parse bhist output into CSV
-python3 - "$TEMP_FILE" "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -171,15 +171,15 @@ echo ""
 echo "Export complete!"
 echo ""
 echo "Statistics:"
-echo "  Total records: $(tail -n +2 "$OUTPUT_FILE" | wc -l)"
-echo "  Output file: $OUTPUT_FILE"
+echo "  Total records: $(tail -n +2 "${OUTPUT_FILE}" | wc -l)"
+echo "  Output file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo "  1. Verify the export:"
-echo "     head $OUTPUT_FILE"
+echo "     head ${OUTPUT_FILE}"
 echo ""
 echo "  2. Run anonymization:"
-echo "     ./anonymize_cluster_data.sh $OUTPUT_FILE lsf_jobs_anonymized.csv mapping_secure.txt"
+echo "     ./anonymize_cluster_data.sh ${OUTPUT_FILE} lsf_jobs_anonymized.csv mapping_secure.txt"
 echo ""
 echo "  3. Secure the mapping file:"
 echo "     chmod 600 mapping_secure.txt"

--- a/export_pbs_cluster_config.sh
+++ b/export_pbs_cluster_config.sh
@@ -13,7 +13,7 @@ echo "================================================================"
 echo "PBS/Torque Cluster Configuration Export"
 echo "================================================================"
 echo ""
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if pbsnodes is available
@@ -27,17 +27,17 @@ fi
 # Detect PBS variant
 PBS_VARIANT="unknown"
 VERSION_OUTPUT=$(pbsnodes --version 2>&1 || echo "")
-if echo "$VERSION_OUTPUT" | grep -qi "pbs pro"; then
+if echo "${VERSION_OUTPUT}" | grep -qi "pbs pro"; then
     PBS_VARIANT="PBS Pro"
-elif echo "$VERSION_OUTPUT" | grep -qi "torque"; then
+elif echo "${VERSION_OUTPUT}" | grep -qi "torque"; then
     PBS_VARIANT="Torque"
-elif echo "$VERSION_OUTPUT" | grep -qi "openpbs"; then
+elif echo "${VERSION_OUTPUT}" | grep -qi "openpbs"; then
     PBS_VARIANT="OpenPBS"
 else
     PBS_VARIANT="PBS"
 fi
 
-echo "Detected PBS variant: $PBS_VARIANT"
+echo "Detected PBS variant: ${PBS_VARIANT}"
 echo ""
 
 TEMP_FILE=$(mktemp)
@@ -48,16 +48,16 @@ echo "Querying all nodes with pbsnodes..."
 # Get all node information
 # -a = all nodes
 # -S = show also unavailable nodes
-pbsnodes -a > "$TEMP_FILE" 2>&1 || {
+pbsnodes -a > "${TEMP_FILE}" 2>&1 || {
     echo "Warning: pbsnodes -a failed, trying without -a"
-    pbsnodes > "$TEMP_FILE"
+    pbsnodes > "${TEMP_FILE}"
 }
 
 echo ""
 echo "Parsing pbsnodes output into CSV format..."
 
 # Parse pbsnodes output into CSV
-python3 - "$TEMP_FILE" "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -210,7 +210,7 @@ echo "PBS CLUSTER CONFIGURATION SUMMARY"
 echo "================================================================"
 
 # Calculate summary statistics
-python3 - "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import csv
 import sys
 
@@ -293,15 +293,15 @@ echo "================================================================"
 echo "EXPORT COMPLETE"
 echo "================================================================"
 echo ""
-echo "Configuration file: $OUTPUT_FILE"
+echo "Configuration file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo ""
 echo "1. Review the configuration:"
-echo "   head -20 $OUTPUT_FILE"
+echo "   head -20 ${OUTPUT_FILE}"
 echo ""
 echo "2. Standardize format (for cross-scheduler comparison):"
-echo "   python3 standardize_cluster_config.py $OUTPUT_FILE"
+echo "   python3 standardize_cluster_config.py ${OUTPUT_FILE}"
 echo ""
 echo "3. Compare with job data to calculate utilization:"
 echo "   # Export job data first:"

--- a/export_pbs_comprehensive.sh
+++ b/export_pbs_comprehensive.sh
@@ -12,8 +12,8 @@ set -euo pipefail
 
 # Load security libraries
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/validation.sh"
-source "$SCRIPT_DIR/security_logging.sh"
+source "${SCRIPT_DIR}/validation.sh"
+source "${SCRIPT_DIR}/security_logging.sh"
 
 # Configuration
 START_DATE="${1:-$(date -d '1 year ago' +%Y%m%d 2>/dev/null || date -v-1y +%Y%m%d)}"
@@ -21,15 +21,15 @@ END_DATE="${2:-$(date +%Y%m%d)}"
 OUTPUT_FILE="pbs_jobs_with_users_$(date +%Y%m%d).csv"
 
 # Validate and sanitize date inputs
-if ! START_DATE=$(validate_and_sanitize_date "$START_DATE" "pbs"); then
-    log_validation_failure "date" "$START_DATE"
+if ! START_DATE=$(validate_and_sanitize_date "${START_DATE}" "pbs"); then
+    log_validation_failure "date" "${START_DATE}"
     echo "ERROR: Invalid start date format" >&2
     echo "Expected: YYYYMMDD (e.g., 20240131)" >&2
     exit 1
 fi
 
-if ! END_DATE=$(validate_and_sanitize_date "$END_DATE" "pbs"); then
-    log_validation_failure "date" "$END_DATE"
+if ! END_DATE=$(validate_and_sanitize_date "${END_DATE}" "pbs"); then
+    log_validation_failure "date" "${END_DATE}"
     echo "ERROR: Invalid end date format" >&2
     echo "Expected: YYYYMMDD (e.g., 20241231)" >&2
     exit 1
@@ -39,23 +39,23 @@ echo "================================================================"
 echo "PBS/Torque Comprehensive Job Data Export"
 echo "================================================================"
 echo ""
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Log export start
-log_export_start "PBS" "start=$START_DATE end=$END_DATE output=$OUTPUT_FILE"
+log_export_start "PBS" "start=${START_DATE} end=${END_DATE} output=${OUTPUT_FILE}"
 
 # Detect PBS variant
 PBS_VARIANT="unknown"
 if command -v qstat &> /dev/null; then
     # Check version string to determine variant
     VERSION_OUTPUT=$(qstat --version 2>&1 || qstat -B 2>&1 || echo "")
-    if echo "$VERSION_OUTPUT" | grep -qi "pbs pro"; then
+    if echo "${VERSION_OUTPUT}" | grep -qi "pbs pro"; then
         PBS_VARIANT="PBS Pro"
-    elif echo "$VERSION_OUTPUT" | grep -qi "torque"; then
+    elif echo "${VERSION_OUTPUT}" | grep -qi "torque"; then
         PBS_VARIANT="Torque"
-    elif echo "$VERSION_OUTPUT" | grep -qi "openpbs"; then
+    elif echo "${VERSION_OUTPUT}" | grep -qi "openpbs"; then
         PBS_VARIANT="OpenPBS"
     else
         PBS_VARIANT="PBS"
@@ -63,24 +63,24 @@ if command -v qstat &> /dev/null; then
 fi
 
 PBS_VERSION=$(qstat --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[^ ]*' | head -1 || echo "unknown")
-echo "Detected PBS variant: $PBS_VARIANT ($PBS_VERSION)"
+echo "Detected PBS variant: ${PBS_VARIANT} (${PBS_VERSION})"
 echo ""
 
 # Find accounting directory
 ACCT_DIR=""
 for dir in \
-    "$PBS_HOME/server_priv/accounting" \
+    "${PBS_HOME}/server_priv/accounting" \
     "/var/spool/pbs/server_priv/accounting" \
     "/var/spool/torque/server_priv/accounting" \
     "/opt/pbs/server_priv/accounting" \
     "/usr/spool/pbs/server_priv/accounting"; do
-    if [ -d "$dir" ]; then
-        ACCT_DIR="$dir"
+    if [[ -d "${dir}" ]]; then
+        ACCT_DIR="${dir}"
         break
     fi
 done
 
-if [ -z "$ACCT_DIR" ]; then
+if [[ -z "${ACCT_DIR}" ]]; then
     echo "ERROR: Cannot find PBS accounting directory"
     echo ""
     echo "Tried:"
@@ -95,9 +95,9 @@ if [ -z "$ACCT_DIR" ]; then
     exit 1
 fi
 
-if [ ! -r "$ACCT_DIR" ]; then
-    if [ "${VERBOSE:-0}" -eq 1 ]; then
-        echo "ERROR: Cannot read accounting directory: $ACCT_DIR"
+if [[ ! -r "${ACCT_DIR}" ]]; then
+    if [[ "${VERBOSE:-0}" -eq 1 ]]; then
+        echo "ERROR: Cannot read accounting directory: ${ACCT_DIR}"
     else
         echo "ERROR: Cannot read accounting directory (set VERBOSE=1 for path)"
     fi
@@ -106,38 +106,38 @@ if [ ! -r "$ACCT_DIR" ]; then
     exit 1
 fi
 
-echo "Using accounting directory: $ACCT_DIR"
+echo "Using accounting directory: ${ACCT_DIR}"
 echo ""
 echo "Finding accounting files in date range..."
 
 # PBS accounting files are named YYYYMMDD
 ACCT_FILES=()
-for date_file in $(ls "$ACCT_DIR" | grep -E '^[0-9]{8}$' | sort); do
-    if [ "$date_file" -ge "$START_DATE" ] && [ "$date_file" -le "$END_DATE" ]; then
-        ACCT_FILES+=("$ACCT_DIR/$date_file")
+for date_file in $(ls "${ACCT_DIR}" | grep -E '^[0-9]{8}$' | sort); do
+    if [[ "${date_file}" -ge "${START_DATE}" ]] && [[ "${date_file}" -le "${END_DATE}" ]]; then
+        ACCT_FILES+=("${ACCT_DIR}/${date_file}")
     fi
 done
 
 # Also check for compressed files
-for date_file in $(ls "$ACCT_DIR" | grep -E '^[0-9]{8}\.(gz|bz2)$' | sed 's/\.(gz|bz2)$//' | sort); do
-    if [ "$date_file" -ge "$START_DATE" ] && [ "$date_file" -le "$END_DATE" ]; then
+for date_file in $(ls "${ACCT_DIR}" | grep -E '^[0-9]{8}\.(gz|bz2)$' | sed 's/\.(gz|bz2)$//' | sort); do
+    if [[ "${date_file}" -ge "${START_DATE}" ]] && [[ "${date_file}" -le "${END_DATE}" ]]; then
         # Check both .gz and .bz2
-        if [ -f "$ACCT_DIR/${date_file}.gz" ]; then
-            ACCT_FILES+=("$ACCT_DIR/${date_file}.gz")
-        elif [ -f "$ACCT_DIR/${date_file}.bz2" ]; then
-            ACCT_FILES+=("$ACCT_DIR/${date_file}.bz2")
+        if [[ -f "${ACCT_DIR}/${date_file}.gz" ]]; then
+            ACCT_FILES+=("${ACCT_DIR}/${date_file}.gz")
+        elif [[ -f "${ACCT_DIR}/${date_file}.bz2" ]]; then
+            ACCT_FILES+=("${ACCT_DIR}/${date_file}.bz2")
         fi
     fi
 done
 
-if [ ${#ACCT_FILES[@]} -eq 0 ]; then
-    echo "ERROR: No accounting files found in date range $START_DATE to $END_DATE"
+if [[ ${#ACCT_FILES[@]} -eq 0 ]]; then
+    echo "ERROR: No accounting files found in date range ${START_DATE} to ${END_DATE}"
     echo ""
 
     # Show directory listing only in verbose mode (avoid information disclosure)
-    if [ "${VERBOSE:-0}" -eq 1 ]; then
-        echo "Available files in $ACCT_DIR:"
-        ls -1 "$ACCT_DIR" | head -20
+    if [[ "${VERBOSE:-0}" -eq 1 ]]; then
+        echo "Available files in ${ACCT_DIR}:"
+        ls -1 "${ACCT_DIR}" | head -20
     else
         echo "Set VERBOSE=1 to see available files"
         echo "Example: VERBOSE=1 ./export_pbs_comprehensive.sh"
@@ -149,10 +149,10 @@ fi
 echo "Found ${#ACCT_FILES[@]} accounting files"
 echo ""
 
-if [ "${VERBOSE:-0}" = "1" ]; then
+if [[ "${VERBOSE:-0}" = "1" ]]; then
     echo "================================================================" >&2
     echo "VERBOSE: Accounting files to be parsed:" >&2
-    for f in "${ACCT_FILES[@]}"; do echo "  $f ($(wc -l < "$f") lines)" >&2; done
+    for f in "${ACCT_FILES[@]}"; do echo "  ${f} ($(wc -l < "${f}") lines)" >&2; done
     echo "VERBOSE: First 5 lines of first file:" >&2
     head -5 "${ACCT_FILES[0]}" >&2
     echo "================================================================" >&2
@@ -161,7 +161,7 @@ fi
 echo "Parsing accounting records..."
 
 # Parse PBS accounting logs
-python3 - "pbs" "${PBS_VARIANT}" "${PBS_VERSION}" "${ACCT_FILES[@]}" "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "pbs" "${PBS_VARIANT}" "${PBS_VERSION}" "${ACCT_FILES[@]}" "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import sys
 import csv
 import os
@@ -488,40 +488,40 @@ VALIDATION_FAILED=0
 
 for file in "${ACCT_FILES[@]}"; do
     # Check file exists
-    if [ ! -e "$file" ]; then
-        echo "ERROR: Accounting file does not exist: $file" >&2
-        log_validation_failure "file_exists" "$file"
+    if [[ ! -e "${file}" ]]; then
+        echo "ERROR: Accounting file does not exist: ${file}" >&2
+        log_validation_failure "file_exists" "${file}"
         VALIDATION_FAILED=1
         continue
     fi
 
     # Check it's a regular file (not directory or special file)
-    if [ ! -f "$file" ]; then
-        echo "ERROR: Not a regular file: $file" >&2
-        log_validation_failure "file_type" "$file"
+    if [[ ! -f "${file}" ]]; then
+        echo "ERROR: Not a regular file: ${file}" >&2
+        log_validation_failure "file_type" "${file}"
         VALIDATION_FAILED=1
         continue
     fi
 
     # Check file is readable
-    if [ ! -r "$file" ]; then
-        echo "ERROR: Cannot read accounting file: $file" >&2
-        log_permission_issue "$file" "read"
+    if [[ ! -r "${file}" ]]; then
+        echo "ERROR: Cannot read accounting file: ${file}" >&2
+        log_permission_issue "${file}" "read"
         VALIDATION_FAILED=1
         continue
     fi
 
     # Check file size is reasonable (not empty, not suspiciously large)
-    file_size=$(stat -f%z "$file" 2>/dev/null || stat -c%s "$file" 2>/dev/null || echo "0")
-    if [ "$file_size" -eq 0 ]; then
-        echo "WARNING: Accounting file is empty: $file" >&2
-        log_validation_failure "file_empty" "$file"
-    elif [ "$file_size" -gt 10737418240 ]; then  # > 10GB
-        echo "WARNING: Accounting file is very large (>10GB): $file" >&2
+    file_size=$(stat -f%z "${file}" 2>/dev/null || stat -c%s "${file}" 2>/dev/null || echo "0")
+    if [[ "${file_size}" -eq 0 ]]; then
+        echo "WARNING: Accounting file is empty: ${file}" >&2
+        log_validation_failure "file_empty" "${file}"
+    elif [[ "${file_size}" -gt 10737418240 ]]; then  # > 10GB
+        echo "WARNING: Accounting file is very large (>10GB): ${file}" >&2
     fi
 done
 
-if [ $VALIDATION_FAILED -eq 1 ]; then
+if [[ "${VALIDATION_FAILED}" -eq 1 ]]; then
     echo "ERROR: Accounting file validation failed" >&2
     echo "Cannot proceed with invalid or inaccessible files" >&2
     exit 1
@@ -534,29 +534,29 @@ echo "================================================================"
 echo "EXPORT COMPLETE"
 echo "================================================================"
 echo ""
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 echo "File details:"
-ls -lh "$OUTPUT_FILE"
+ls -lh "${OUTPUT_FILE}"
 echo ""
 echo "First few records:"
-head -5 "$OUTPUT_FILE"
+head -5 "${OUTPUT_FILE}"
 echo ""
 echo "================================================================"
 echo "NEXT STEPS"
 echo "================================================================"
 echo ""
 echo "1. Verify the export looks correct:"
-echo "   head -20 $OUTPUT_FILE"
-echo "   tail -20 $OUTPUT_FILE"
+echo "   head -20 ${OUTPUT_FILE}"
+echo "   tail -20 ${OUTPUT_FILE}"
 echo ""
 echo "2. Check statistics:"
-echo "   wc -l $OUTPUT_FILE"
-echo "   cut -d, -f1 $OUTPUT_FILE | sort -u | wc -l  # Unique users"
+echo "   wc -l ${OUTPUT_FILE}"
+echo "   cut -d, -f1 ${OUTPUT_FILE} | sort -u | wc -l  # Unique users"
 echo ""
 echo "3. Anonymize the data:"
 echo "   ./anonymize_cluster_data.sh \\"
-echo "     $OUTPUT_FILE \\"
+echo "     ${OUTPUT_FILE} \\"
 echo "     pbs_jobs_anonymized.csv \\"
 echo "     pbs_mapping_secure.txt"
 echo ""

--- a/export_pbs_data.sh
+++ b/export_pbs_data.sh
@@ -36,7 +36,8 @@ echo "Reading accounting logs..."
 # PBS/Torque accounting logs are typically in /var/spool/pbs/server_priv/accounting/
 # PBS Pro logs are in /var/spool/pbs/server_logs/
 
-ACCT_DIR="/var/spool/pbs/server_priv/accounting"
+# PBS_ACCT_DIR (if set) overrides the default locations.
+ACCT_DIR="${PBS_ACCT_DIR:-/var/spool/pbs/server_priv/accounting}"
 if [ ! -d "$ACCT_DIR" ]; then
     ACCT_DIR="/var/spool/pbs/server_logs"
 fi

--- a/export_pbs_data.sh
+++ b/export_pbs_data.sh
@@ -14,8 +14,8 @@ END_DATE="${2:-$(date +%Y%m%d)}"
 OUTPUT_FILE="pbs_jobs_with_users_$(date +%Y%m%d).csv"
 
 echo "Exporting PBS/Torque job data with user/group information..."
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check which PBS command is available
@@ -38,11 +38,11 @@ echo "Reading accounting logs..."
 
 # PBS_ACCT_DIR (if set) overrides the default locations.
 ACCT_DIR="${PBS_ACCT_DIR:-/var/spool/pbs/server_priv/accounting}"
-if [ ! -d "$ACCT_DIR" ]; then
+if [[ ! -d "${ACCT_DIR}" ]]; then
     ACCT_DIR="/var/spool/pbs/server_logs"
 fi
 
-if [ ! -d "$ACCT_DIR" ]; then
+if [[ ! -d "${ACCT_DIR}" ]]; then
     echo "ERROR: Cannot find PBS accounting directory"
     echo "Tried: /var/spool/pbs/server_priv/accounting"
     echo "       /var/spool/pbs/server_logs"
@@ -53,7 +53,7 @@ if [ ! -d "$ACCT_DIR" ]; then
 fi
 
 # Parse accounting logs
-python3 - "$ACCT_DIR" "$START_DATE" "$END_DATE" "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${ACCT_DIR}" "${START_DATE}" "${END_DATE}" "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import sys
 import csv
 import os
@@ -219,15 +219,15 @@ echo ""
 echo "Export complete!"
 echo ""
 echo "Statistics:"
-echo "  Total records: $(tail -n +2 "$OUTPUT_FILE" | wc -l)"
-echo "  Output file: $OUTPUT_FILE"
+echo "  Total records: $(tail -n +2 "${OUTPUT_FILE}" | wc -l)"
+echo "  Output file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo "  1. Verify the export:"
-echo "     head $OUTPUT_FILE"
+echo "     head ${OUTPUT_FILE}"
 echo ""
 echo "  2. Run anonymization:"
-echo "     ./anonymize_cluster_data.sh $OUTPUT_FILE pbs_jobs_anonymized.csv mapping_secure.txt"
+echo "     ./anonymize_cluster_data.sh ${OUTPUT_FILE} pbs_jobs_anonymized.csv mapping_secure.txt"
 echo ""
 echo "  3. Secure the mapping file:"
 echo "     chmod 600 mapping_secure.txt"

--- a/export_slurm_cluster_config.sh
+++ b/export_slurm_cluster_config.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 OUTPUT_FILE="slurm_cluster_config_$(date +%Y%m%d).csv"
 
 echo "Exporting SLURM cluster configuration..."
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if sinfo is available
@@ -21,19 +21,19 @@ fi
 echo "Querying cluster configuration..."
 
 # Export with sinfo - shows ALL nodes regardless of whether they ran jobs
-sinfo -N -o "%N,%c,%m,%G,%P,%T,%C" --noheader > "$OUTPUT_FILE.tmp"
+sinfo -N -o "%N,%c,%m,%G,%P,%T,%C" --noheader > "${OUTPUT_FILE}.tmp"
 
 # Add header
-echo "NodeName,CPUs,Memory,Gres,Partition,State,CPUAllocation" > "$OUTPUT_FILE"
-cat "$OUTPUT_FILE.tmp" >> "$OUTPUT_FILE"
-rm "$OUTPUT_FILE.tmp"
+echo "NodeName,CPUs,Memory,Gres,Partition,State,CPUAllocation" > "${OUTPUT_FILE}"
+cat "${OUTPUT_FILE}.tmp" >> "${OUTPUT_FILE}"
+rm "${OUTPUT_FILE}.tmp"
 
 echo ""
 echo "Cluster configuration exported!"
 echo ""
 
 # Calculate summary statistics
-python3 - "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import csv
 import sys
 
@@ -113,7 +113,7 @@ print("="*80)
 PYTHON_EOF
 
 echo ""
-echo "Configuration details saved to: $OUTPUT_FILE"
+echo "Configuration details saved to: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo "  1. Compare with job data to calculate true utilization"

--- a/export_uge_cluster_config.sh
+++ b/export_uge_cluster_config.sh
@@ -13,7 +13,7 @@ echo "================================================================"
 echo "UGE/SGE Cluster Configuration Export"
 echo "================================================================"
 echo ""
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if qhost is available
@@ -29,18 +29,18 @@ fi
 GE_VARIANT="unknown"
 if command -v qconf &> /dev/null; then
     VERSION_OUTPUT=$(qconf -help 2>&1 || qconf -sobjl 2>&1 || echo "")
-    if echo "$VERSION_OUTPUT" | grep -qi "univa"; then
+    if echo "${VERSION_OUTPUT}" | grep -qi "univa"; then
         GE_VARIANT="Univa Grid Engine (UGE)"
-    elif echo "$VERSION_OUTPUT" | grep -qi "open grid"; then
+    elif echo "${VERSION_OUTPUT}" | grep -qi "open grid"; then
         GE_VARIANT="Open Grid Engine (OGE)"
-    elif echo "$VERSION_OUTPUT" | grep -qi "sun grid"; then
+    elif echo "${VERSION_OUTPUT}" | grep -qi "sun grid"; then
         GE_VARIANT="Sun Grid Engine (SGE)"
     else
         GE_VARIANT="Grid Engine"
     fi
 fi
 
-echo "Detected variant: $GE_VARIANT"
+echo "Detected variant: ${GE_VARIANT}"
 echo ""
 
 TEMP_XML=$(mktemp)
@@ -50,12 +50,12 @@ trap 'rm -f "$TEMP_XML" "$TEMP_TEXT"' EXIT
 echo "Querying all execution hosts with qhost..."
 
 # Try XML output first (more reliable parsing)
-if qhost -F -xml > "$TEMP_XML" 2>/dev/null; then
+if qhost -F -xml > "${TEMP_XML}" 2>/dev/null; then
     echo "Using XML output format"
     USE_XML=true
 else
     echo "XML not available, using text format"
-    qhost -F > "$TEMP_TEXT"
+    qhost -F > "${TEMP_TEXT}"
     USE_XML=false
 fi
 
@@ -63,7 +63,7 @@ echo ""
 echo "Parsing qhost output into CSV format..."
 
 # Parse qhost output into CSV
-python3 - "$USE_XML" "$TEMP_XML" "$TEMP_TEXT" "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${USE_XML}" "${TEMP_XML}" "${TEMP_TEXT}" "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -250,7 +250,7 @@ echo "UGE/SGE CLUSTER CONFIGURATION SUMMARY"
 echo "================================================================"
 
 # Calculate summary statistics
-python3 - "$OUTPUT_FILE" << 'PYTHON_EOF'
+python3 - "${OUTPUT_FILE}" << 'PYTHON_EOF'
 import csv
 import sys
 
@@ -312,15 +312,15 @@ echo "================================================================"
 echo "EXPORT COMPLETE"
 echo "================================================================"
 echo ""
-echo "Configuration file: $OUTPUT_FILE"
+echo "Configuration file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo ""
 echo "1. Review the configuration:"
-echo "   head -20 $OUTPUT_FILE"
+echo "   head -20 ${OUTPUT_FILE}"
 echo ""
 echo "2. Standardize format (for cross-scheduler comparison):"
-echo "   python3 standardize_cluster_config.py $OUTPUT_FILE"
+echo "   python3 standardize_cluster_config.py ${OUTPUT_FILE}"
 echo ""
 echo "3. Compare with job data to calculate utilization:"
 echo "   # Export job data first:"

--- a/export_uge_comprehensive.sh
+++ b/export_uge_comprehensive.sh
@@ -17,8 +17,8 @@ set -euo pipefail
 
 # Load security libraries
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/validation.sh"
-source "$SCRIPT_DIR/security_logging.sh"
+source "${SCRIPT_DIR}/validation.sh"
+source "${SCRIPT_DIR}/security_logging.sh"
 
 # Configuration
 START_DATE="${1:-01/01/$(date -d '1 year ago' +%Y 2>/dev/null || date -v-1y +%Y)}"
@@ -26,15 +26,15 @@ END_DATE="${2:-$(date +%m/%d/%Y)}"
 OUTPUT_FILE="uge_jobs_with_users_$(date +%Y%m%d).csv"
 
 # Validate and sanitize date inputs
-if ! START_DATE=$(validate_and_sanitize_date "$START_DATE" "uge"); then
-    log_validation_failure "date" "$START_DATE"
+if ! START_DATE=$(validate_and_sanitize_date "${START_DATE}" "uge"); then
+    log_validation_failure "date" "${START_DATE}"
     echo "ERROR: Invalid start date format" >&2
     echo "Expected: MM/DD/YYYY (e.g., 01/31/2024)" >&2
     exit 1
 fi
 
-if ! END_DATE=$(validate_and_sanitize_date "$END_DATE" "uge"); then
-    log_validation_failure "date" "$END_DATE"
+if ! END_DATE=$(validate_and_sanitize_date "${END_DATE}" "uge"); then
+    log_validation_failure "date" "${END_DATE}"
     echo "ERROR: Invalid end date format" >&2
     echo "Expected: MM/DD/YYYY (e.g., 12/31/2024)" >&2
     exit 1
@@ -44,12 +44,12 @@ echo "================================================================"
 echo "UGE/SGE Comprehensive Job Data Export"
 echo "================================================================"
 echo ""
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Log export start
-log_export_start "UGE" "start=$START_DATE end=$END_DATE output=$OUTPUT_FILE"
+log_export_start "UGE" "start=${START_DATE} end=${END_DATE} output=${OUTPUT_FILE}"
 
 # Check if qacct is available
 if ! command -v qacct &> /dev/null; then
@@ -64,11 +64,11 @@ fi
 GE_VARIANT="unknown"
 if command -v qconf &> /dev/null; then
     VERSION_OUTPUT=$(qconf -help 2>&1 || qconf -sobjl 2>&1 || echo "")
-    if echo "$VERSION_OUTPUT" | grep -qi "univa"; then
+    if echo "${VERSION_OUTPUT}" | grep -qi "univa"; then
         GE_VARIANT="Univa Grid Engine (UGE)"
-    elif echo "$VERSION_OUTPUT" | grep -qi "open grid"; then
+    elif echo "${VERSION_OUTPUT}" | grep -qi "open grid"; then
         GE_VARIANT="Open Grid Engine (OGE)"
-    elif echo "$VERSION_OUTPUT" | grep -qi "sun grid"; then
+    elif echo "${VERSION_OUTPUT}" | grep -qi "sun grid"; then
         GE_VARIANT="Sun Grid Engine (SGE)"
     else
         GE_VARIANT="Grid Engine"
@@ -76,14 +76,14 @@ if command -v qconf &> /dev/null; then
 fi
 
 GE_VERSION=$(qconf -help 2>&1 | grep -oE '[0-9]+\.[0-9]+[^ ]*' | head -1 || echo "unknown")
-echo "Detected variant: $GE_VARIANT ($GE_VERSION)"
+echo "Detected variant: ${GE_VARIANT} (${GE_VERSION})"
 echo ""
 
 # Check accounting file access
-if [ -n "$SGE_ROOT" ]; then
-    ACCT_FILE="$SGE_ROOT/default/common/accounting"
-    if [ -f "$ACCT_FILE" ]; then
-        echo "Found accounting file: $ACCT_FILE"
+if [[ -n "${SGE_ROOT}" ]]; then
+    ACCT_FILE="${SGE_ROOT}/default/common/accounting"
+    if [[ -f "${ACCT_FILE}" ]]; then
+        echo "Found accounting file: ${ACCT_FILE}"
     fi
 fi
 
@@ -97,37 +97,37 @@ if command -v qconf &> /dev/null; then
     # Get list of all PEs
     PE_LIST=$(qconf -spl 2>/dev/null || echo "")
 
-    if [ -n "$PE_LIST" ]; then
+    if [[ -n "${PE_LIST}" ]]; then
         # For each PE, get its allocation rule
-        echo "pe_name,allocation_rule,slots_per_host" > "$PE_CONFIG_FILE"
+        echo "pe_name,allocation_rule,slots_per_host" > "${PE_CONFIG_FILE}"
 
-        for pe in $PE_LIST; do
-            PE_DETAILS=$(qconf -sp "$pe" 2>/dev/null || echo "")
-            if [ -n "$PE_DETAILS" ]; then
+        for pe in ${PE_LIST}; do
+            PE_DETAILS=$(qconf -sp "${pe}" 2>/dev/null || echo "")
+            if [[ -n "${PE_DETAILS}" ]]; then
                 # Extract allocation_rule
-                ALLOC_RULE=$(echo "$PE_DETAILS" | grep "^allocation_rule" | awk '{print $2}')
+                ALLOC_RULE=$(echo "${PE_DETAILS}" | grep "^allocation_rule" | awk '{print $2}')
 
                 # Determine slots per host from allocation rule
-                if [[ "$ALLOC_RULE" =~ ^[0-9]+$ ]]; then
+                if [[ "${ALLOC_RULE}" =~ ^[0-9]+$ ]]; then
                     # Fixed number = slots per host
-                    SLOTS_PER_HOST="$ALLOC_RULE"
-                elif [[ "$ALLOC_RULE" == "\$pe_slots" ]]; then
+                    SLOTS_PER_HOST="${ALLOC_RULE}"
+                elif [[ "${ALLOC_RULE}" == "\$pe_slots" ]]; then
                     # All on one host (SMP)
                     SLOTS_PER_HOST="SMP"
-                elif [[ "$ALLOC_RULE" == "\$fill_up" ]]; then
+                elif [[ "${ALLOC_RULE}" == "\$fill_up" ]]; then
                     SLOTS_PER_HOST="fill_up"
-                elif [[ "$ALLOC_RULE" == "\$round_robin" ]]; then
+                elif [[ "${ALLOC_RULE}" == "\$round_robin" ]]; then
                     SLOTS_PER_HOST="round_robin"
                 else
                     SLOTS_PER_HOST="unknown"
                 fi
 
-                echo "$pe,$ALLOC_RULE,$SLOTS_PER_HOST" >> "$PE_CONFIG_FILE"
+                echo "${pe},${ALLOC_RULE},${SLOTS_PER_HOST}" >> "${PE_CONFIG_FILE}"
             fi
         done
 
-        NUM_PES=$(tail -n +2 "$PE_CONFIG_FILE" | wc -l | tr -d ' ')
-        echo "Found $NUM_PES parallel environments"
+        NUM_PES=$(tail -n +2 "${PE_CONFIG_FILE}" | wc -l | tr -d ' ')
+        echo "Found ${NUM_PES} parallel environments"
     else
         echo "No parallel environments configured or access denied"
     fi
@@ -143,7 +143,7 @@ echo ""
 # -e end_time (MM/DD/YYYY format)
 # -j for all jobs (optional job ID filter)
 
-qacct -b "$START_DATE" -e "$END_DATE" > "$TEMP_FILE" 2>&1 || {
+qacct -b "${START_DATE}" -e "${END_DATE}" > "${TEMP_FILE}" 2>&1 || {
 
     echo "ERROR: qacct query failed"
     echo ""
@@ -152,24 +152,24 @@ qacct -b "$START_DATE" -e "$END_DATE" > "$TEMP_FILE" 2>&1 || {
     echo "  - Accounting file not readable"
     echo "  - Date format incorrect (should be MM/DD/YYYY)"
     echo ""
-    cat "$TEMP_FILE"
+    cat "${TEMP_FILE}"
     exit 1
 }
 
 echo ""
 
-if [ "${VERBOSE:-0}" = "1" ]; then
+if [[ "${VERBOSE:-0}" = "1" ]]; then
     echo "================================================================" >&2
     echo "VERBOSE: Raw qacct output (first 30 lines):" >&2
-    head -30 "$TEMP_FILE" >&2
-    echo "  ... ($(wc -l < "$TEMP_FILE") total lines)" >&2
+    head -30 "${TEMP_FILE}" >&2
+    echo "  ... ($(wc -l < "${TEMP_FILE}") total lines)" >&2
     echo "================================================================" >&2
 fi
 
 echo "Parsing qacct output into standardized CSV format..."
 
 # Parse qacct output into CSV
-python3 - "$TEMP_FILE" "$PE_CONFIG_FILE" "$OUTPUT_FILE" "uge" "$GE_VARIANT" "$GE_VERSION" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${PE_CONFIG_FILE}" "${OUTPUT_FILE}" "uge" "${GE_VARIANT}" "${GE_VERSION}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -537,29 +537,29 @@ echo "================================================================"
 echo "EXPORT COMPLETE"
 echo "================================================================"
 echo ""
-echo "Output file: $OUTPUT_FILE"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 echo "File details:"
-ls -lh "$OUTPUT_FILE"
+ls -lh "${OUTPUT_FILE}"
 echo ""
 echo "First few records:"
-head -5 "$OUTPUT_FILE"
+head -5 "${OUTPUT_FILE}"
 echo ""
 echo "================================================================"
 echo "NEXT STEPS"
 echo "================================================================"
 echo ""
 echo "1. Verify the export looks correct:"
-echo "   head -20 $OUTPUT_FILE"
-echo "   tail -20 $OUTPUT_FILE"
+echo "   head -20 ${OUTPUT_FILE}"
+echo "   tail -20 ${OUTPUT_FILE}"
 echo ""
 echo "2. Check statistics:"
-echo "   wc -l $OUTPUT_FILE"
-echo "   cut -d, -f1 $OUTPUT_FILE | sort -u | wc -l  # Unique users"
+echo "   wc -l ${OUTPUT_FILE}"
+echo "   cut -d, -f1 ${OUTPUT_FILE} | sort -u | wc -l  # Unique users"
 echo ""
 echo "3. Anonymize the data:"
 echo "   ./anonymize_cluster_data.sh \\"
-echo "     $OUTPUT_FILE \\"
+echo "     ${OUTPUT_FILE} \\"
 echo "     uge_jobs_anonymized.csv \\"
 echo "     uge_mapping_secure.txt"
 echo ""

--- a/export_uge_data.sh
+++ b/export_uge_data.sh
@@ -16,8 +16,8 @@ END_DATE="${2:-$(date +%m/%d/%Y)}"
 OUTPUT_FILE="uge_jobs_with_users_$(date +%Y%m%d).csv"
 
 echo "Exporting UGE/SGE job data with user/group information..."
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Check if qacct is available
@@ -35,14 +35,14 @@ echo "Querying accounting database (this may take several minutes)..."
 TEMP_FILE=$(mktemp)
 trap 'rm -f "$TEMP_FILE"' EXIT
 
-qacct -b "$START_DATE" -e "$END_DATE" > "$TEMP_FILE"
+qacct -b "${START_DATE}" -e "${END_DATE}" > "${TEMP_FILE}"
 
 echo "Parsing accounting data into CSV format..."
 
 UGE_VERSION=$(qconf -help 2>&1 | grep -oE '[0-9]+\.[0-9]+[^ ]*' | head -1 || echo "unknown")
 
 # Parse qacct output into CSV
-python3 - "$TEMP_FILE" "$OUTPUT_FILE" "uge" "$UGE_VERSION" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${OUTPUT_FILE}" "uge" "${UGE_VERSION}" << 'PYTHON_EOF'
 import sys
 import csv
 from datetime import datetime
@@ -135,15 +135,15 @@ echo ""
 echo "Export complete!"
 echo ""
 echo "Statistics:"
-echo "  Total records: $(tail -n +2 "$OUTPUT_FILE" | wc -l)"
-echo "  Output file: $OUTPUT_FILE"
+echo "  Total records: $(tail -n +2 "${OUTPUT_FILE}" | wc -l)"
+echo "  Output file: ${OUTPUT_FILE}"
 echo ""
 echo "Next steps:"
 echo "  1. Verify the export:"
-echo "     head $OUTPUT_FILE"
+echo "     head ${OUTPUT_FILE}"
 echo ""
 echo "  2. Run anonymization:"
-echo "     ./anonymize_cluster_data.sh $OUTPUT_FILE uge_jobs_anonymized.csv mapping_secure.txt"
+echo "     ./anonymize_cluster_data.sh ${OUTPUT_FILE} uge_jobs_anonymized.csv mapping_secure.txt"
 echo ""
 echo "  3. Secure the mapping file:"
 echo "     chmod 600 mapping_secure.txt"

--- a/export_with_users.sh
+++ b/export_with_users.sh
@@ -17,23 +17,23 @@ set -euo pipefail
 
 # Load security libraries
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/validation.sh"
-source "$SCRIPT_DIR/security_logging.sh"
+source "${SCRIPT_DIR}/validation.sh"
+source "${SCRIPT_DIR}/security_logging.sh"
 
 # Date range configuration (command-line arguments or defaults)
 START_DATE="${1:-$(date -d '1 year ago' '+%Y-%m-%d' 2>/dev/null || date -v-1y '+%Y-%m-%d')}"
 END_DATE="${2:-$(date '+%Y-%m-%d')}"
 
 # Validate and sanitize date inputs
-if ! START_DATE=$(validate_and_sanitize_date "$START_DATE" "slurm"); then
-    log_validation_failure "date" "$START_DATE"
+if ! START_DATE=$(validate_and_sanitize_date "${START_DATE}" "slurm"); then
+    log_validation_failure "date" "${START_DATE}"
     echo "ERROR: Invalid start date format" >&2
     echo "Expected: YYYY-MM-DD (e.g., 2024-01-31)" >&2
     exit 1
 fi
 
-if ! END_DATE=$(validate_and_sanitize_date "$END_DATE" "slurm"); then
-    log_validation_failure "date" "$END_DATE"
+if ! END_DATE=$(validate_and_sanitize_date "${END_DATE}" "slurm"); then
+    log_validation_failure "date" "${END_DATE}"
     echo "ERROR: Invalid end date format" >&2
     echo "Expected: YYYY-MM-DD (e.g., 2024-12-31)" >&2
     exit 1
@@ -48,38 +48,38 @@ echo "================================================================"
 echo "SLURM Job Data Export with User Information"
 echo "================================================================"
 echo ""
-echo "Date range: $START_DATE to $END_DATE"
-echo "Output file: $OUTPUT_FILE"
+echo "Date range: ${START_DATE} to ${END_DATE}"
+echo "Output file: ${OUTPUT_FILE}"
 echo ""
 
 # Log export start
-log_export_start "SLURM" "start=$START_DATE end=$END_DATE output=$OUTPUT_FILE"
+log_export_start "SLURM" "start=${START_DATE} end=${END_DATE} output=${OUTPUT_FILE}"
 
 # Detect SLURM version for metadata column
 SLURM_VERSION=$(sinfo --version 2>/dev/null | awk '{print $NF}' || echo "unknown")
-echo "Detected SLURM version: $SLURM_VERSION"
+echo "Detected SLURM version: ${SLURM_VERSION}"
 
 # Export with sacct (pipe-separated output)
 echo "Querying SLURM accounting database..."
 sacct -a \
   --format=User,Group,Account,JobID,JobName,ReqCPUS,ReqMem,NNodes,NodeList,Submit,Start,End,ExitCode,State,MaxRSS,TotalCPU,Elapsed,AllocCPUS,Partition,QOS,Priority,Reservation,AllocTRES \
-  --starttime "$START_DATE" \
-  --endtime "$END_DATE" \
+  --starttime "${START_DATE}" \
+  --endtime "${END_DATE}" \
   --parsable2 \
-  > "$TEMP_FILE"
+  > "${TEMP_FILE}"
 
-if [ "${VERBOSE:-0}" = "1" ]; then
+if [[ "${VERBOSE:-0}" = "1" ]]; then
     echo "================================================================" >&2
     echo "VERBOSE: Raw sacct output (first 5 lines):" >&2
-    head -5 "$TEMP_FILE" >&2
-    echo "  ... ($(wc -l < "$TEMP_FILE") total lines)" >&2
+    head -5 "${TEMP_FILE}" >&2
+    echo "  ... ($(wc -l < "${TEMP_FILE}") total lines)" >&2
     echo "================================================================" >&2
 fi
 
 echo "Converting to standardized CSV format..."
 
 # Convert pipe-separated sacct output to standardized comma-separated CSV
-python3 - "$TEMP_FILE" "$OUTPUT_FILE" "slurm" "$SLURM_VERSION" << 'PYTHON_EOF'
+python3 - "${TEMP_FILE}" "${OUTPUT_FILE}" "slurm" "${SLURM_VERSION}" << 'PYTHON_EOF'
 import sys
 import csv
 import re
@@ -377,22 +377,22 @@ echo "================================================================"
 echo ""
 
 # Calculate statistics and log completion
-TOTAL_JOBS=$(tail -n +2 "$OUTPUT_FILE" | wc -l)
-log_export_complete "SLURM" "$TOTAL_JOBS" "$OUTPUT_FILE"
+TOTAL_JOBS=$(tail -n +2 "${OUTPUT_FILE}" | wc -l)
+log_export_complete "SLURM" "${TOTAL_JOBS}" "${OUTPUT_FILE}"
 
 # Generate integrity checksum
-generate_checksum "$OUTPUT_FILE"
+generate_checksum "${OUTPUT_FILE}"
 
 echo "Statistics:"
-echo "  Output file: $OUTPUT_FILE"
-echo "  Total jobs: $TOTAL_JOBS"
+echo "  Output file: ${OUTPUT_FILE}"
+echo "  Total jobs: ${TOTAL_JOBS}"
 echo ""
 echo "Next steps:"
 echo "  1. Verify the export looks correct:"
-echo "     head $OUTPUT_FILE"
+echo "     head ${OUTPUT_FILE}"
 echo ""
 echo "  2. Run anonymization:"
-echo "     ./anonymize_cluster_data.sh $OUTPUT_FILE slurm_anonymized.csv mapping_secure.txt"
+echo "     ./anonymize_cluster_data.sh ${OUTPUT_FILE} slurm_anonymized.csv mapping_secure.txt"
 echo ""
 echo "  3. Secure the mapping file:"
 echo "     chmod 600 mapping_secure.txt"

--- a/lint_python.sh
+++ b/lint_python.sh
@@ -55,23 +55,23 @@ extract_python() {
 
     while IFS= read -r line; do
         # Start of Python block
-        if [[ "$line" =~ python3[[:space:]]*\<\<[[:space:]]*[\'\"]*PYTHON_EOF[\'\"]*[[:space:]]*$ ]]; then
+        if [[ "${line}" =~ python3[[:space:]]*\<\<[[:space:]]*[\'\"]*PYTHON_EOF[\'\"]*[[:space:]]*$ ]]; then
             in_python=1
             python_block=""
             continue
         fi
 
         # End of Python block
-        if [[ "$line" =~ ^PYTHON_EOF[[:space:]]*$ ]] && [ $in_python -eq 1 ]; then
+        if [[ "${line}" =~ ^PYTHON_EOF[[:space:]]*$ ]] && [[ "${in_python}" -eq 1 ]]; then
             in_python=0
             block_num=$((block_num + 1))
 
             # Write Python block to file
-            local basename=$(basename "$bash_script" .sh)
-            local output_file="$output_dir/${basename}_block${block_num}.py"
-            echo "$python_block" > "$output_file"
+            local basename=$(basename "${bash_script}" .sh)
+            local output_file="${output_dir}/${basename}_block${block_num}.py"
+            echo "${python_block}" > "${output_file}"
 
-            echo "  ├─ Block $block_num: ${basename}_block${block_num}.py"
+            echo "  ├─ Block ${block_num}: ${basename}_block${block_num}.py"
             PYTHON_BLOCKS=$((PYTHON_BLOCKS + 1))
 
             python_block=""
@@ -79,31 +79,31 @@ extract_python() {
         fi
 
         # Inside Python block - collect lines
-        if [ $in_python -eq 1 ]; then
+        if [[ "${in_python}" -eq 1 ]]; then
             python_block="${python_block}${line}"$'\n'
         fi
-    done < "$bash_script"
+    done < "${bash_script}"
 
-    return $block_num
+    return "${block_num}"
 }
 
 # Process all export scripts
 for script in export_*.sh anonymize_cluster_data.sh; do
-    if [ ! -f "$script" ]; then
+    if [[ ! -f "${script}" ]]; then
         continue
     fi
 
-    echo "Processing: $script"
+    echo "Processing: ${script}"
     SCRIPTS_FOUND=$((SCRIPTS_FOUND + 1))
 
-    extract_python "$script" "$TEMP_DIR"
+    extract_python "${script}" "${TEMP_DIR}"
     echo ""
 done
 
 # Also check standalone Python files
-if [ -f "standardize_cluster_config.py" ]; then
+if [[ -f "standardize_cluster_config.py" ]]; then
     echo "Processing: standardize_cluster_config.py (standalone)"
-    cp standardize_cluster_config.py "$TEMP_DIR/"
+    cp standardize_cluster_config.py "${TEMP_DIR}/"
     PYTHON_BLOCKS=$((PYTHON_BLOCKS + 1))
     echo "  └─ Copied standalone Python file"
     echo ""
@@ -113,11 +113,11 @@ echo "================================================================"
 echo "EXTRACTION COMPLETE"
 echo "================================================================"
 echo ""
-echo "Bash scripts processed: $SCRIPTS_FOUND"
-echo "Python blocks extracted: $PYTHON_BLOCKS"
+echo "Bash scripts processed: ${SCRIPTS_FOUND}"
+echo "Python blocks extracted: ${PYTHON_BLOCKS}"
 echo ""
 
-if [ $PYTHON_BLOCKS -eq 0 ]; then
+if [[ "${PYTHON_BLOCKS}" -eq 0 ]]; then
     echo "WARNING: No Python code found to lint!"
     exit 0
 fi
@@ -128,13 +128,13 @@ echo "================================================================"
 echo ""
 
 # Run ruff on extracted Python files
-if ruff check "$TEMP_DIR" --config pyproject.toml; then
+if ruff check "${TEMP_DIR}" --config pyproject.toml; then
     echo ""
     echo "================================================================"
     echo "✓ ALL CHECKS PASSED"
     echo "================================================================"
     echo ""
-    echo "No linting errors found in $PYTHON_BLOCKS Python code blocks!"
+    echo "No linting errors found in ${PYTHON_BLOCKS} Python code blocks!"
     exit 0
 else
     LINT_ERRORS=$?
@@ -145,11 +145,11 @@ else
     echo ""
     echo "Found issues in extracted Python code."
     echo ""
-    echo "To see detailed output, extracted files are in: $TEMP_DIR"
+    echo "To see detailed output, extracted files are in: ${TEMP_DIR}"
     echo "(They will be deleted when this script exits)"
     echo ""
     echo "To fix issues automatically where possible:"
-    echo "  ruff check $TEMP_DIR --fix"
+    echo "  ruff check ${TEMP_DIR} --fix"
     echo ""
-    exit $LINT_ERRORS
+    exit "${LINT_ERRORS}"
 fi

--- a/run_bandit.sh
+++ b/run_bandit.sh
@@ -35,11 +35,11 @@ echo ""
 
 PYTHON_FILES=$(find . -name "*.py" -not -path "./.git/*" -not -path "./venv/*" -not -path "./.venv/*")
 
-if [ -z "$PYTHON_FILES" ]; then
+if [[ -z "${PYTHON_FILES}" ]]; then
     echo "No Python files found to scan"
 else
     echo "Found Python files:"
-    echo "$PYTHON_FILES" | sed 's/^/  /'
+    echo "${PYTHON_FILES}" | sed 's/^/  /'
     echo ""
 
     bandit -c .bandit -r . -f screen

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -147,11 +147,11 @@ echo "================================================================"
 echo "FINAL SUMMARY"
 echo "================================================================"
 echo ""
-echo "Checks passed: $CHECKS_PASSED"
-echo "Checks failed: $CHECKS_FAILED"
+echo "Checks passed: ${CHECKS_PASSED}"
+echo "Checks failed: ${CHECKS_FAILED}"
 echo ""
 
-if [ $CHECKS_FAILED -eq 0 ]; then
+if [[ "${CHECKS_FAILED}" -eq 0 ]]; then
     echo "✓ ALL QUALITY CHECKS PASSED"
     exit 0
 else

--- a/run_shellcheck.sh
+++ b/run_shellcheck.sh
@@ -35,13 +35,13 @@ echo ""
 echo "Finding bash scripts..."
 SCRIPTS=$(find . -name "*.sh" -not -path "./.git/*" -not -path "./venv/*" -not -path "./.venv/*")
 
-if [ -z "$SCRIPTS" ]; then
+if [[ -z "${SCRIPTS}" ]]; then
     echo "No bash scripts found"
     exit 0
 fi
 
 echo "Found bash scripts:"
-echo "$SCRIPTS" | sed 's/^/  /'
+echo "${SCRIPTS}" | sed 's/^/  /'
 echo ""
 echo "Running ShellCheck..."
 echo ""
@@ -51,15 +51,15 @@ ERRORS=0
 WARNINGS=0
 PASSED=0
 
-for script in $SCRIPTS; do
-    echo "Checking: $script"
+for script in ${SCRIPTS}; do
+    echo "Checking: ${script}"
 
     # Run shellcheck and capture output
-    if shellcheck "$script"; then
+    if shellcheck "${script}"; then
         PASSED=$((PASSED + 1))
     else
         exit_code=$?
-        if [ $exit_code -eq 1 ]; then
+        if [[ "${exit_code}" -eq 1 ]]; then
             ERRORS=$((ERRORS + 1))
         else
             WARNINGS=$((WARNINGS + 1))
@@ -72,13 +72,13 @@ echo "================================================================"
 echo "ShellCheck Results"
 echo "================================================================"
 echo ""
-echo "Scripts checked: $(echo "$SCRIPTS" | wc -l | tr -d ' ')"
-echo "Passed: $PASSED"
-echo "Warnings: $WARNINGS"
-echo "Errors: $ERRORS"
+echo "Scripts checked: $(echo "${SCRIPTS}" | wc -l | tr -d ' ')"
+echo "Passed: ${PASSED}"
+echo "Warnings: ${WARNINGS}"
+echo "Errors: ${ERRORS}"
 echo ""
 
-if [ $ERRORS -eq 0 ]; then
+if [[ "${ERRORS}" -eq 0 ]]; then
     echo "✓ All scripts passed ShellCheck"
     exit 0
 else

--- a/security_logging.sh
+++ b/security_logging.sh
@@ -11,9 +11,9 @@ SECURITY_LOG="${SECURITY_LOG:-${HOME}/.cluster-export-security.log}"
 
 # Initialize log file with secure permissions
 init_security_log() {
-    if [ ! -f "$SECURITY_LOG" ]; then
-        touch "$SECURITY_LOG"
-        chmod 600 "$SECURITY_LOG"
+    if [[ ! -f "${SECURITY_LOG}" ]]; then
+        touch "${SECURITY_LOG}"
+        chmod 600 "${SECURITY_LOG}"
     fi
 }
 
@@ -31,7 +31,7 @@ log_security_event() {
     local pid=$$
 
     # Format: [timestamp] [user] [script:pid] [LEVEL] message
-    echo "[$timestamp] [$user] [$script:$pid] [$level] $message" >> "$SECURITY_LOG"
+    echo "[${timestamp}] [${user}] [${script}:${pid}] [${level}] ${message}" >> "${SECURITY_LOG}"
 }
 
 # Convenience wrappers
@@ -44,7 +44,7 @@ log_export_start() {
     shift
     local args="$*"
 
-    log_security_event "INFO" "Export started: scheduler=$scheduler args='$args'"
+    log_security_event "INFO" "Export started: scheduler=${scheduler} args='${args}'"
 }
 
 # Log export completion
@@ -53,7 +53,7 @@ log_export_complete() {
     local records="$2"
     local output_file="$3"
 
-    log_security_event "INFO" "Export completed: scheduler=$scheduler records=$records output='$output_file'"
+    log_security_event "INFO" "Export completed: scheduler=${scheduler} records=${records} output='${output_file}'"
 }
 
 # Log validation failure
@@ -62,9 +62,9 @@ log_validation_failure() {
     local input="$2"
 
     # Sanitize input before logging to prevent log injection
-    input=$(echo "$input" | tr -d '\n\r' | cut -c1-100)
+    input=$(echo "${input}" | tr -d '\n\r' | cut -c1-100)
 
-    log_security_event "WARN" "Validation failed: type=$validation_type input='$input'"
+    log_security_event "WARN" "Validation failed: type=${validation_type} input='${input}'"
 }
 
 # Log suspicious input detection
@@ -73,9 +73,9 @@ log_suspicious_input() {
     local reason="$2"
 
     # Sanitize input before logging
-    input=$(echo "$input" | tr -d '\n\r' | cut -c1-100)
+    input=$(echo "${input}" | tr -d '\n\r' | cut -c1-100)
 
-    log_security_event "ALERT" "Suspicious input detected: reason='$reason' input='$input'"
+    log_security_event "ALERT" "Suspicious input detected: reason='${reason}' input='${input}'"
 }
 
 # Log anonymization operation
@@ -84,7 +84,7 @@ log_anonymization() {
     local output_file="$2"
     local records="$3"
 
-    log_security_event "INFO" "Anonymization: input='$(basename "$input_file")' output='$(basename "$output_file")' records=$records"
+    log_security_event "INFO" "Anonymization: input='$(basename "${input_file}")' output='$(basename "${output_file}")' records=${records}"
 }
 
 # Log file access attempt
@@ -93,7 +93,7 @@ log_file_access() {
     local file="$2"
     local result="$3"
 
-    log_security_event "INFO" "File access: operation=$operation file='$(basename "$file")' result=$result"
+    log_security_event "INFO" "File access: operation=${operation} file='$(basename "${file}")' result=${result}"
 }
 
 # Log permission issue
@@ -101,7 +101,7 @@ log_permission_issue() {
     local resource="$1"
     local required_permission="$2"
 
-    log_security_event "ERROR" "Permission denied: resource='$resource' required='$required_permission'"
+    log_security_event "ERROR" "Permission denied: resource='${resource}' required='${required_permission}'"
 }
 
 # Log security check result
@@ -110,19 +110,19 @@ log_security_check() {
     local result="$2"
     local details="$3"
 
-    log_security_event "INFO" "Security check: name='$check_name' result=$result details='$details'"
+    log_security_event "INFO" "Security check: name='${check_name}' result=${result} details='${details}'"
 }
 
 # View recent security log entries
 show_security_log() {
     local lines="${1:-20}"
 
-    if [ -f "$SECURITY_LOG" ]; then
-        echo "Recent security events (last $lines):"
+    if [[ -f "${SECURITY_LOG}" ]]; then
+        echo "Recent security events (last ${lines}):"
         echo "========================================"
-        tail -n "$lines" "$SECURITY_LOG"
+        tail -n "${lines}" "${SECURITY_LOG}"
     else
-        echo "No security log found at: $SECURITY_LOG"
+        echo "No security log found at: ${SECURITY_LOG}"
     fi
 }
 
@@ -130,32 +130,32 @@ show_security_log() {
 search_security_log() {
     local pattern="$1"
 
-    if [ -f "$SECURITY_LOG" ]; then
-        echo "Security events matching: $pattern"
+    if [[ -f "${SECURITY_LOG}" ]]; then
+        echo "Security events matching: ${pattern}"
         echo "========================================"
-        grep -i "$pattern" "$SECURITY_LOG"
+        grep -i "${pattern}" "${SECURITY_LOG}"
     else
-        echo "No security log found at: $SECURITY_LOG"
+        echo "No security log found at: ${SECURITY_LOG}"
     fi
 }
 
 # Get security statistics
 security_stats() {
-    if [ ! -f "$SECURITY_LOG" ]; then
+    if [[ ! -f "${SECURITY_LOG}" ]]; then
         echo "No security log found"
         return
     fi
 
     echo "Security Log Statistics"
     echo "========================================"
-    echo "Log file: $SECURITY_LOG"
-    echo "Total events: $(wc -l < "$SECURITY_LOG")"
+    echo "Log file: ${SECURITY_LOG}"
+    echo "Total events: $(wc -l < "${SECURITY_LOG}")"
     echo ""
     echo "Events by level:"
-    grep -oE '\[(INFO|WARN|ERROR|ALERT)\]' "$SECURITY_LOG" | sort | uniq -c | sort -rn
+    grep -oE '\[(INFO|WARN|ERROR|ALERT)\]' "${SECURITY_LOG}" | sort | uniq -c | sort -rn
     echo ""
     echo "Recent alerts (last 10):"
-    grep '\[ALERT\]' "$SECURITY_LOG" | tail -10
+    grep '\[ALERT\]' "${SECURITY_LOG}" | tail -10
 }
 
 # Generate SHA256 checksum for file integrity verification
@@ -163,36 +163,36 @@ generate_checksum() {
     local file="$1"
     local checksum_file="${file}.sha256"
 
-    if [ ! -f "$file" ]; then
-        log_error "Cannot generate checksum: file not found: $file"
+    if [[ ! -f "${file}" ]]; then
+        log_error "Cannot generate checksum: file not found: ${file}"
         return 1
     fi
 
     # Generate checksum
     if command -v sha256sum &> /dev/null; then
-        sha256sum "$file" > "$checksum_file"
+        sha256sum "${file}" > "${checksum_file}"
     elif command -v shasum &> /dev/null; then
-        shasum -a 256 "$file" > "$checksum_file"
+        shasum -a 256 "${file}" > "${checksum_file}"
     else
         log_error "No SHA256 tool available (tried sha256sum, shasum)"
         return 1
     fi
 
     # Secure the checksum file
-    chmod 600 "$checksum_file"
+    chmod 600 "${checksum_file}"
 
-    log_info "Checksum generated: $checksum_file"
+    log_info "Checksum generated: ${checksum_file}"
     echo ""
     echo "File Integrity Checksum:"
-    echo "  File: $(basename "$file")"
-    echo "  SHA256: $(cat "$checksum_file")"
-    echo "  Checksum file: $checksum_file"
+    echo "  File: $(basename "${file}")"
+    echo "  SHA256: $(cat "${checksum_file}")"
+    echo "  Checksum file: ${checksum_file}"
     echo ""
     echo "Verify integrity with:"
     if command -v sha256sum &> /dev/null; then
-        echo "  sha256sum -c $checksum_file"
+        echo "  sha256sum -c ${checksum_file}"
     else
-        echo "  shasum -a 256 -c $checksum_file"
+        echo "  shasum -a 256 -c ${checksum_file}"
     fi
 
     return 0
@@ -203,30 +203,30 @@ verify_checksum() {
     local file="$1"
     local checksum_file="${file}.sha256"
 
-    if [ ! -f "$checksum_file" ]; then
-        log_error "Checksum file not found: $checksum_file"
+    if [[ ! -f "${checksum_file}" ]]; then
+        log_error "Checksum file not found: ${checksum_file}"
         return 1
     fi
 
-    echo "Verifying checksum for: $(basename "$file")"
+    echo "Verifying checksum for: $(basename "${file}")"
 
     if command -v sha256sum &> /dev/null; then
-        if sha256sum -c "$checksum_file" 2>&1 | grep -q "OK"; then
-            log_info "Checksum verification: PASS for $file"
+        if sha256sum -c "${checksum_file}" 2>&1 | grep -q "OK"; then
+            log_info "Checksum verification: PASS for ${file}"
             echo "✓ Checksum verification: PASS"
             return 0
         else
-            log_security_event "ALERT" "Checksum verification FAILED for $file"
+            log_security_event "ALERT" "Checksum verification FAILED for ${file}"
             echo "✗ Checksum verification: FAILED"
             return 1
         fi
     elif command -v shasum &> /dev/null; then
-        if shasum -a 256 -c "$checksum_file" 2>&1 | grep -q "OK"; then
-            log_info "Checksum verification: PASS for $file"
+        if shasum -a 256 -c "${checksum_file}" 2>&1 | grep -q "OK"; then
+            log_info "Checksum verification: PASS for ${file}"
             echo "✓ Checksum verification: PASS"
             return 0
         else
-            log_security_event "ALERT" "Checksum verification FAILED for $file"
+            log_security_event "ALERT" "Checksum verification FAILED for ${file}"
             echo "✗ Checksum verification: FAILED"
             return 1
         fi

--- a/security_tests.sh
+++ b/security_tests.sh
@@ -34,26 +34,26 @@ test_result() {
 
     # Run the command and capture exit code
     set +e
-    eval "$command" >/dev/null 2>&1
+    eval "${command}" >/dev/null 2>&1
     local exit_code=$?
     set -e
 
-    if [ "$expected_exit" -eq 0 ]; then
+    if [[ "${expected_exit}" -eq 0 ]]; then
         # Should succeed
-        if [ $exit_code -eq 0 ]; then
-            echo -e "${GREEN}✓ PASS${NC}: $test_name"
+        if [[ "${exit_code}" -eq 0 ]]; then
+            echo -e "${GREEN}✓ PASS${NC}: ${test_name}"
             TESTS_PASSED=$((TESTS_PASSED + 1))
         else
-            echo -e "${RED}✗ FAIL${NC}: $test_name (expected success, got exit $exit_code)"
+            echo -e "${RED}✗ FAIL${NC}: ${test_name} (expected success, got exit ${exit_code})"
             TESTS_FAILED=$((TESTS_FAILED + 1))
         fi
     else
         # Should fail
-        if [ $exit_code -ne 0 ]; then
-            echo -e "${GREEN}✓ PASS${NC}: $test_name (correctly rejected)"
+        if [[ "${exit_code}" -ne 0 ]]; then
+            echo -e "${GREEN}✓ PASS${NC}: ${test_name} (correctly rejected)"
             TESTS_PASSED=$((TESTS_PASSED + 1))
         else
-            echo -e "${RED}✗ FAIL${NC}: $test_name (should have rejected input)"
+            echo -e "${RED}✗ FAIL${NC}: ${test_name} (should have rejected input)"
             TESTS_FAILED=$((TESTS_FAILED + 1))
         fi
     fi
@@ -105,8 +105,8 @@ echo ""
 
 # Create test CSV for anonymization tests
 TEST_CSV=$(mktemp)
-echo "user,group,job_id" > "$TEST_CSV"
-echo "testuser,testgroup,12345" >> "$TEST_CSV"
+echo "user,group,job_id" > "${TEST_CSV}"
+echo "testuser,testgroup,12345" >> "${TEST_CSV}"
 trap 'rm -f "$TEST_CSV"' EXIT
 
 # Test 2.1: Parent directory traversal
@@ -132,13 +132,13 @@ echo ""
 # Test 3.1: Very long date string
 LONG_DATE=$(python3 -c "print('2024-01-01' + 'A' * 10000)")
 test_result "Long input - 10KB date string" \
-    "./export_with_users.sh '$LONG_DATE' 2024-12-31" \
+    "./export_with_users.sh '${LONG_DATE}' 2024-12-31" \
     1
 
 # Test 3.2: Very long filename
 LONG_FILENAME=$(python3 -c "print('A' * 5000 + '.csv')")
 test_result "Long input - 5KB filename" \
-    "./anonymize_cluster_data.sh '$TEST_CSV' '$LONG_FILENAME' /tmp/map.txt" \
+    "./anonymize_cluster_data.sh '${TEST_CSV}' '${LONG_FILENAME}' /tmp/map.txt" \
     1
 
 echo ""
@@ -191,7 +191,7 @@ if command -v bhist &> /dev/null; then
 fi
 
 # Test 5.3: Valid PBS date (if PBS available)
-if command -v qstat &> /dev/null && [ -d "/var/spool/pbs/server_priv/accounting" ]; then
+if command -v qstat &> /dev/null && [[ -d "/var/spool/pbs/server_priv/accounting" ]]; then
     test_result "Valid input - PBS date" \
         "sudo ./export_pbs_comprehensive.sh 20240101 20240102" \
         0
@@ -206,7 +206,7 @@ fi
 
 # Test 5.5: Valid anonymization
 test_result "Valid input - anonymization" \
-    "./anonymize_cluster_data.sh '$TEST_CSV' /tmp/test_out.csv /tmp/test_map.txt" \
+    "./anonymize_cluster_data.sh '${TEST_CSV}' /tmp/test_out.csv /tmp/test_map.txt" \
     0
 
 # Cleanup
@@ -217,12 +217,12 @@ echo "================================================================"
 echo "SECURITY TEST RESULTS"
 echo "================================================================"
 echo ""
-echo "Total tests: $TESTS_TOTAL"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "Total tests: ${TESTS_TOTAL}"
+echo -e "Passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Failed: ${RED}${TESTS_FAILED}${NC}"
 echo ""
 
-if [ $TESTS_FAILED -eq 0 ]; then
+if [[ "${TESTS_FAILED}" -eq 0 ]]; then
     echo -e "${GREEN}✓ ALL SECURITY TESTS PASSED${NC}"
     echo ""
     echo "All injection attempts were correctly blocked."

--- a/test_exports.sh
+++ b/test_exports.sh
@@ -45,7 +45,7 @@ echo ""
 echo "Test 1: Python 3 availability"
 if command -v python3 &> /dev/null; then
     PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
-    pass_test "Python 3 found (version $PYTHON_VERSION)"
+    pass_test "Python 3 found (version ${PYTHON_VERSION})"
 else
     fail_test "Python 3 not found"
 fi
@@ -54,11 +54,11 @@ echo ""
 # Test 2: Check bash is recent enough
 echo "Test 2: Bash version"
 BASH_VERSION_NUM=$(bash --version | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
-BASH_MAJOR=$(echo "$BASH_VERSION_NUM" | cut -d. -f1)
-if [ "$BASH_MAJOR" -ge 3 ]; then
-    pass_test "Bash version acceptable ($BASH_VERSION_NUM)"
+BASH_MAJOR=$(echo "${BASH_VERSION_NUM}" | cut -d. -f1)
+if [[ "${BASH_MAJOR}" -ge 3 ]]; then
+    pass_test "Bash version acceptable (${BASH_VERSION_NUM})"
 else
-    fail_test "Bash version too old ($BASH_VERSION_NUM < 3.0)"
+    fail_test "Bash version too old (${BASH_VERSION_NUM} < 3.0)"
 fi
 echo ""
 
@@ -67,22 +67,22 @@ echo "Test 3: Export scripts are executable"
 SCRIPTS_OK=0
 SCRIPTS_BAD=0
 for script in export_*.sh anonymize_cluster_data.sh; do
-    if [ ! -f "$script" ]; then
+    if [[ ! -f "${script}" ]]; then
         continue
     fi
 
-    if [ -x "$script" ]; then
+    if [[ -x "${script}" ]]; then
         SCRIPTS_OK=$((SCRIPTS_OK + 1))
     else
-        echo "  → $script is not executable"
+        echo "  → ${script} is not executable"
         SCRIPTS_BAD=$((SCRIPTS_BAD + 1))
     fi
 done
 
-if [ $SCRIPTS_BAD -eq 0 ]; then
-    pass_test "All $SCRIPTS_OK export scripts are executable"
+if [[ "${SCRIPTS_BAD}" -eq 0 ]]; then
+    pass_test "All ${SCRIPTS_OK} export scripts are executable"
 else
-    fail_test "$SCRIPTS_BAD scripts are not executable (run: chmod +x *.sh)"
+    fail_test "${SCRIPTS_BAD} scripts are not executable (run: chmod +x *.sh)"
 fi
 echo ""
 
@@ -91,7 +91,7 @@ echo "Test 4: Python syntax validation"
 SYNTAX_ERRORS=0
 
 for script in export_*.sh anonymize_cluster_data.sh; do
-    if [ ! -f "$script" ]; then
+    if [[ ! -f "${script}" ]]; then
         continue
     fi
 
@@ -101,22 +101,22 @@ for script in export_*.sh anonymize_cluster_data.sh; do
     block_num=0
 
     while IFS= read -r line; do
-        if [[ "$line" =~ python3[[:space:]]*\<\<[[:space:]]*[\'\"]*PYTHON_EOF[\'\"]*[[:space:]]*$ ]]; then
+        if [[ "${line}" =~ python3[[:space:]]*\<\<[[:space:]]*[\'\"]*PYTHON_EOF[\'\"]*[[:space:]]*$ ]]; then
             in_python=1
             python_code=""
             continue
         fi
 
-        if [[ "$line" =~ ^PYTHON_EOF[[:space:]]*$ ]] && [ $in_python -eq 1 ]; then
+        if [[ "${line}" =~ ^PYTHON_EOF[[:space:]]*$ ]] && [[ "${in_python}" -eq 1 ]]; then
             in_python=0
             block_num=$((block_num + 1))
 
             # Test syntax by writing to temp file
-            TEST_FILE="$TEMP_DIR/syntax_test_${block_num}.py"
-            echo "$python_code" > "$TEST_FILE"
+            TEST_FILE="${TEMP_DIR}/syntax_test_${block_num}.py"
+            echo "${python_code}" > "${TEST_FILE}"
 
-            if ! python3 -m py_compile "$TEST_FILE" 2>/dev/null; then
-                echo "  → Syntax error in $script (block $block_num)"
+            if ! python3 -m py_compile "${TEST_FILE}" 2>/dev/null; then
+                echo "  → Syntax error in ${script} (block ${block_num})"
                 SYNTAX_ERRORS=$((SYNTAX_ERRORS + 1))
             fi
 
@@ -124,16 +124,16 @@ for script in export_*.sh anonymize_cluster_data.sh; do
             continue
         fi
 
-        if [ $in_python -eq 1 ]; then
+        if [[ "${in_python}" -eq 1 ]]; then
             python_code="${python_code}${line}"$'\n'
         fi
-    done < "$script"
+    done < "${script}"
 done
 
-if [ $SYNTAX_ERRORS -eq 0 ]; then
+if [[ "${SYNTAX_ERRORS}" -eq 0 ]]; then
     pass_test "No Python syntax errors found"
 else
-    fail_test "Found $SYNTAX_ERRORS Python syntax errors"
+    fail_test "Found ${SYNTAX_ERRORS} Python syntax errors"
 fi
 echo ""
 
@@ -142,16 +142,16 @@ echo "Test 5: Standard library import check"
 MISSING_IMPORTS=0
 
 for module in csv sys datetime re os collections gzip bz2; do
-    if ! python3 -c "import $module" 2>/dev/null; then
-        echo "  → Missing module: $module"
+    if ! python3 -c "import ${module}" 2>/dev/null; then
+        echo "  → Missing module: ${module}"
         MISSING_IMPORTS=$((MISSING_IMPORTS + 1))
     fi
 done
 
-if [ $MISSING_IMPORTS -eq 0 ]; then
+if [[ "${MISSING_IMPORTS}" -eq 0 ]]; then
     pass_test "All required standard library modules available"
 else
-    fail_test "Missing $MISSING_IMPORTS required modules"
+    fail_test "Missing ${MISSING_IMPORTS} required modules"
 fi
 echo ""
 
@@ -159,7 +159,7 @@ echo ""
 echo "Test 6: Anonymization script functionality"
 
 # Create sample input CSV
-cat > "$TEMP_DIR/test_input.csv" << 'EOF'
+cat > "${TEMP_DIR}/test_input.csv" << 'EOF'
 user,group,account,job_id,nodelist,cpus
 alice,research,proj_a,12345,node001.example.com,16
 bob,physics,proj_b,12346,node002.example.com,32
@@ -167,18 +167,18 @@ alice,research,proj_a,12347,node001.example.com,16
 EOF
 
 # Test if anonymize script exists and can run
-if [ -f "anonymize_cluster_data.sh" ] && [ -x "anonymize_cluster_data.sh" ]; then
+if [[ -f "anonymize_cluster_data.sh" ]] && [[ -x "anonymize_cluster_data.sh" ]]; then
     if ./anonymize_cluster_data.sh \
-        "$TEMP_DIR/test_input.csv" \
-        "$TEMP_DIR/test_output.csv" \
-        "$TEMP_DIR/test_mapping.txt" \
-        &> "$TEMP_DIR/anon_test.log"; then
+        "${TEMP_DIR}/test_input.csv" \
+        "${TEMP_DIR}/test_output.csv" \
+        "${TEMP_DIR}/test_mapping.txt" \
+        &> "${TEMP_DIR}/anon_test.log"; then
 
         # Verify output was created
-        if [ -f "$TEMP_DIR/test_output.csv" ]; then
+        if [[ -f "${TEMP_DIR}/test_output.csv" ]]; then
             # Check that users were anonymized
-            if grep -q "user_0001" "$TEMP_DIR/test_output.csv" && \
-               ! grep -q "alice" "$TEMP_DIR/test_output.csv"; then
+            if grep -q "user_0001" "${TEMP_DIR}/test_output.csv" && \
+               ! grep -q "alice" "${TEMP_DIR}/test_output.csv"; then
                 pass_test "Anonymization script works correctly"
             else
                 fail_test "Anonymization did not transform usernames"
@@ -196,7 +196,7 @@ echo ""
 
 # Test 7: Check README documentation exists
 echo "Test 7: Documentation check"
-if [ -f "README.md" ]; then
+if [[ -f "README.md" ]]; then
     # Check for key sections
     MISSING_SECTIONS=""
 
@@ -210,10 +210,10 @@ if [ -f "README.md" ]; then
         MISSING_SECTIONS="${MISSING_SECTIONS}What Gets Exported, "
     fi
 
-    if [ -z "$MISSING_SECTIONS" ]; then
+    if [[ -z "${MISSING_SECTIONS}" ]]; then
         pass_test "README documentation is complete"
     else
-        fail_test "README missing sections: $MISSING_SECTIONS"
+        fail_test "README missing sections: ${MISSING_SECTIONS}"
     fi
 else
     fail_test "README.md not found"
@@ -226,21 +226,21 @@ if command -v shellcheck &> /dev/null; then
     SHELLCHECK_ERRORS=0
 
     for script in export_*.sh anonymize_cluster_data.sh lint_python.sh test_exports.sh; do
-        if [ ! -f "$script" ]; then
+        if [[ ! -f "${script}" ]]; then
             continue
         fi
 
         # Run shellcheck (only check for errors, not style warnings)
         # Use -S error to only report actual errors, not warnings/style/info
-        if ! shellcheck -S error "$script" &> /dev/null; then
+        if ! shellcheck -S error "${script}" &> /dev/null; then
             SHELLCHECK_ERRORS=$((SHELLCHECK_ERRORS + 1))
         fi
     done
 
-    if [ $SHELLCHECK_ERRORS -eq 0 ]; then
+    if [[ "${SHELLCHECK_ERRORS}" -eq 0 ]]; then
         pass_test "All shell scripts pass shellcheck (errors only)"
     else
-        fail_test "$SHELLCHECK_ERRORS scripts have shellcheck errors"
+        fail_test "${SHELLCHECK_ERRORS} scripts have shellcheck errors"
     fi
 else
     skip_test "shellcheck not installed (optional but recommended)"
@@ -257,11 +257,11 @@ PERMISSION_ISSUES=0
 source security_logging.sh
 init_security_log
 
-if [ -f "$SECURITY_LOG" ]; then
+if [[ -f "${SECURITY_LOG}" ]]; then
     # Get file permissions (portable way)
-    if ls -l "$SECURITY_LOG" | grep -q '^-rw-------'; then
+    if ls -l "${SECURITY_LOG}" | grep -q '^-rw-------'; then
         : # Permissions are correct (600)
-    elif ls -l "$SECURITY_LOG" | grep -q '^-rw-r--r--'; then
+    elif ls -l "${SECURITY_LOG}" | grep -q '^-rw-r--r--'; then
         echo "  → Security log has weak permissions (644 instead of 600)"
         PERMISSION_ISSUES=$((PERMISSION_ISSUES + 1))
     else
@@ -271,10 +271,10 @@ if [ -f "$SECURITY_LOG" ]; then
 fi
 
 # Test anonymization creates secure mapping file
-TEST_MAP="$TEMP_DIR/test_mapping.txt"
-if ./anonymize_cluster_data.sh "$TEMP_DIR/test_input.csv" "$TEMP_DIR/test_anon_output.csv" "$TEST_MAP" &> /dev/null; then
-    if [ -f "$TEST_MAP" ]; then
-        if ls -l "$TEST_MAP" | grep -q '^-rw-------'; then
+TEST_MAP="${TEMP_DIR}/test_mapping.txt"
+if ./anonymize_cluster_data.sh "${TEMP_DIR}/test_input.csv" "${TEMP_DIR}/test_anon_output.csv" "${TEST_MAP}" &> /dev/null; then
+    if [[ -f "${TEST_MAP}" ]]; then
+        if ls -l "${TEST_MAP}" | grep -q '^-rw-------'; then
             : # Permissions are correct (600)
         else
             echo "  → Mapping file has weak permissions (should be 600)"
@@ -284,10 +284,10 @@ if ./anonymize_cluster_data.sh "$TEMP_DIR/test_input.csv" "$TEMP_DIR/test_anon_o
 fi
 
 # Test that checksum files are created with secure permissions
-TEST_FILE="$TEMP_DIR/test_checksum.csv"
-echo "test,data" > "$TEST_FILE"
-if generate_checksum "$TEST_FILE" &> /dev/null; then
-    if [ -f "${TEST_FILE}.sha256" ]; then
+TEST_FILE="${TEMP_DIR}/test_checksum.csv"
+echo "test,data" > "${TEST_FILE}"
+if generate_checksum "${TEST_FILE}" &> /dev/null; then
+    if [[ -f "${TEST_FILE}.sha256" ]]; then
         if ls -l "${TEST_FILE}.sha256" | grep -q '^-rw-------'; then
             : # Permissions are correct (600)
         else
@@ -297,10 +297,10 @@ if generate_checksum "$TEST_FILE" &> /dev/null; then
     fi
 fi
 
-if [ $PERMISSION_ISSUES -eq 0 ]; then
+if [[ "${PERMISSION_ISSUES}" -eq 0 ]]; then
     pass_test "All sensitive files have secure permissions (600)"
 else
-    fail_test "$PERMISSION_ISSUES files have insecure permissions"
+    fail_test "${PERMISSION_ISSUES} files have insecure permissions"
 fi
 echo ""
 
@@ -309,11 +309,11 @@ echo "================================================================"
 echo "TEST SUMMARY"
 echo "================================================================"
 echo ""
-echo -e "Tests passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Tests failed: ${RED}$TESTS_FAILED${NC}"
+echo -e "Tests passed: ${GREEN}${TESTS_PASSED}${NC}"
+echo -e "Tests failed: ${RED}${TESTS_FAILED}${NC}"
 echo ""
 
-if [ $TESTS_FAILED -eq 0 ]; then
+if [[ "${TESTS_FAILED}" -eq 0 ]]; then
     echo -e "${GREEN}✓ ALL TESTS PASSED${NC}"
     echo ""
     exit 0

--- a/tests/test_integration.bats
+++ b/tests/test_integration.bats
@@ -79,6 +79,19 @@ MOCK
     export PATH="$mock_dir:$PATH"
 }
 
+mock_qstat() {
+    # PBS parses accounting files directly; qstat only needs to exist so the
+    # script's "which PBS command is available" gate passes.
+    local mock_dir="$TEST_DIR/mock_bin"
+    mkdir -p "$mock_dir"
+    cat > "$mock_dir/qstat" << MOCK
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$mock_dir/qstat"
+    export PATH="$mock_dir:$PATH"
+}
+
 mock_condor_history() {
     local mock_dir="$TEST_DIR/mock_bin"
     mkdir -p "$mock_dir"
@@ -213,6 +226,32 @@ MOCK
     [[ "$header" == *"user"* ]]
     [[ "$header" == *"job_id"* ]]
     [[ "$header" == *"cpus_req"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# PBS: export_pbs_data.sh
+# ---------------------------------------------------------------------------
+# PBS reads accounting files from a directory rather than a mocked binary, so
+# the fixture directory is injected via PBS_ACCT_DIR (honored by the script).
+# The fixture dir contains an accounting file named 20240115, hence the date
+# range below.
+
+@test "PBS export_pbs_data: runs end-to-end and produces CSV" {
+    mock_qstat
+    run env PBS_ACCT_DIR="$FIXTURES/pbs" bash "$REPO_ROOT/export_pbs_data.sh" 20240115 20240115
+    [ "$status" -eq 0 ]
+    csv_file=$(ls pbs_jobs_*.csv 2>/dev/null | head -1)
+    [ -n "$csv_file" ]
+}
+
+@test "PBS export_pbs_data: output CSV has expected header" {
+    mock_qstat
+    PBS_ACCT_DIR="$FIXTURES/pbs" bash "$REPO_ROOT/export_pbs_data.sh" 20240115 20240115 >/dev/null 2>&1
+    csv_file=$(ls pbs_jobs_*.csv 2>/dev/null | head -1)
+    header=$(head -1 "$csv_file")
+    [[ "$header" == *"user"* ]]
+    [[ "$header" == *"job_id"* ]]
+    [[ "$header" == *"scheduler"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/validation.sh
+++ b/validation.sh
@@ -9,29 +9,29 @@
 # Validate SLURM date format: YYYY-MM-DD
 validate_date_slurm() {
     local date="$1"
-    if [[ ! "$date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ ! "${date}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
         echo "ERROR: Invalid SLURM date format. Expected: YYYY-MM-DD (e.g., 2024-01-31)" >&2
         return 1
     fi
 
     # Additional validation: check ranges
     local year month day
-    year=$(echo "$date" | cut -d- -f1)
-    month=$(echo "$date" | cut -d- -f2)
-    day=$(echo "$date" | cut -d- -f3)
+    year=$(echo "${date}" | cut -d- -f1)
+    month=$(echo "${date}" | cut -d- -f2)
+    day=$(echo "${date}" | cut -d- -f3)
 
-    if [ "$year" -lt 2000 ] || [ "$year" -gt 2099 ]; then
-        echo "ERROR: Year out of range (2000-2099): $year" >&2
+    if [[ "${year}" -lt 2000 ]] || [[ "${year}" -gt 2099 ]]; then
+        echo "ERROR: Year out of range (2000-2099): ${year}" >&2
         return 1
     fi
 
-    if [ "$month" -lt 1 ] || [ "$month" -gt 12 ]; then
-        echo "ERROR: Month out of range (01-12): $month" >&2
+    if [[ "${month}" -lt 1 ]] || [[ "${month}" -gt 12 ]]; then
+        echo "ERROR: Month out of range (01-12): ${month}" >&2
         return 1
     fi
 
-    if [ "$day" -lt 1 ] || [ "$day" -gt 31 ]; then
-        echo "ERROR: Day out of range (01-31): $day" >&2
+    if [[ "${day}" -lt 1 ]] || [[ "${day}" -gt 31 ]]; then
+        echo "ERROR: Day out of range (01-31): ${day}" >&2
         return 1
     fi
 
@@ -41,28 +41,28 @@ validate_date_slurm() {
 # Validate LSF date format: YYYY/MM/DD
 validate_date_lsf() {
     local date="$1"
-    if [[ ! "$date" =~ ^[0-9]{4}/[0-9]{2}/[0-9]{2}$ ]]; then
+    if [[ ! "${date}" =~ ^[0-9]{4}/[0-9]{2}/[0-9]{2}$ ]]; then
         echo "ERROR: Invalid LSF date format. Expected: YYYY/MM/DD (e.g., 2024/01/31)" >&2
         return 1
     fi
 
     local year month day
-    year=$(echo "$date" | cut -d/ -f1)
-    month=$(echo "$date" | cut -d/ -f2)
-    day=$(echo "$date" | cut -d/ -f3)
+    year=$(echo "${date}" | cut -d/ -f1)
+    month=$(echo "${date}" | cut -d/ -f2)
+    day=$(echo "${date}" | cut -d/ -f3)
 
-    if [ "$year" -lt 2000 ] || [ "$year" -gt 2099 ]; then
-        echo "ERROR: Year out of range (2000-2099): $year" >&2
+    if [[ "${year}" -lt 2000 ]] || [[ "${year}" -gt 2099 ]]; then
+        echo "ERROR: Year out of range (2000-2099): ${year}" >&2
         return 1
     fi
 
-    if [ "$month" -lt 1 ] || [ "$month" -gt 12 ]; then
-        echo "ERROR: Month out of range (01-12): $month" >&2
+    if [[ "${month}" -lt 1 ]] || [[ "${month}" -gt 12 ]]; then
+        echo "ERROR: Month out of range (01-12): ${month}" >&2
         return 1
     fi
 
-    if [ "$day" -lt 1 ] || [ "$day" -gt 31 ]; then
-        echo "ERROR: Day out of range (01-31): $day" >&2
+    if [[ "${day}" -lt 1 ]] || [[ "${day}" -gt 31 ]]; then
+        echo "ERROR: Day out of range (01-31): ${day}" >&2
         return 1
     fi
 
@@ -72,7 +72,7 @@ validate_date_lsf() {
 # Validate PBS date format: YYYYMMDD
 validate_date_pbs() {
     local date="$1"
-    if [[ ! "$date" =~ ^[0-9]{8}$ ]]; then
+    if [[ ! "${date}" =~ ^[0-9]{8}$ ]]; then
         echo "ERROR: Invalid PBS date format. Expected: YYYYMMDD (e.g., 20240131)" >&2
         return 1
     fi
@@ -82,18 +82,18 @@ validate_date_pbs() {
     month="${date:4:2}"
     day="${date:6:2}"
 
-    if [ "$year" -lt 2000 ] || [ "$year" -gt 2099 ]; then
-        echo "ERROR: Year out of range (2000-2099): $year" >&2
+    if [[ "${year}" -lt 2000 ]] || [[ "${year}" -gt 2099 ]]; then
+        echo "ERROR: Year out of range (2000-2099): ${year}" >&2
         return 1
     fi
 
-    if [ "$month" -lt 1 ] || [ "$month" -gt 12 ]; then
-        echo "ERROR: Month out of range (01-12): $month" >&2
+    if [[ "${month}" -lt 1 ]] || [[ "${month}" -gt 12 ]]; then
+        echo "ERROR: Month out of range (01-12): ${month}" >&2
         return 1
     fi
 
-    if [ "$day" -lt 1 ] || [ "$day" -gt 31 ]; then
-        echo "ERROR: Day out of range (01-31): $day" >&2
+    if [[ "${day}" -lt 1 ]] || [[ "${day}" -gt 31 ]]; then
+        echo "ERROR: Day out of range (01-31): ${day}" >&2
         return 1
     fi
 
@@ -103,28 +103,28 @@ validate_date_pbs() {
 # Validate UGE date format: MM/DD/YYYY
 validate_date_uge() {
     local date="$1"
-    if [[ ! "$date" =~ ^[0-9]{2}/[0-9]{2}/[0-9]{4}$ ]]; then
+    if [[ ! "${date}" =~ ^[0-9]{2}/[0-9]{2}/[0-9]{4}$ ]]; then
         echo "ERROR: Invalid UGE date format. Expected: MM/DD/YYYY (e.g., 01/31/2024)" >&2
         return 1
     fi
 
     local month day year
-    month=$(echo "$date" | cut -d/ -f1)
-    day=$(echo "$date" | cut -d/ -f2)
-    year=$(echo "$date" | cut -d/ -f3)
+    month=$(echo "${date}" | cut -d/ -f1)
+    day=$(echo "${date}" | cut -d/ -f2)
+    year=$(echo "${date}" | cut -d/ -f3)
 
-    if [ "$year" -lt 2000 ] || [ "$year" -gt 2099 ]; then
-        echo "ERROR: Year out of range (2000-2099): $year" >&2
+    if [[ "${year}" -lt 2000 ]] || [[ "${year}" -gt 2099 ]]; then
+        echo "ERROR: Year out of range (2000-2099): ${year}" >&2
         return 1
     fi
 
-    if [ "$month" -lt 1 ] || [ "$month" -gt 12 ]; then
-        echo "ERROR: Month out of range (01-12): $month" >&2
+    if [[ "${month}" -lt 1 ]] || [[ "${month}" -gt 12 ]]; then
+        echo "ERROR: Month out of range (01-12): ${month}" >&2
         return 1
     fi
 
-    if [ "$day" -lt 1 ] || [ "$day" -gt 31 ]; then
-        echo "ERROR: Day out of range (01-31): $day" >&2
+    if [[ "${day}" -lt 1 ]] || [[ "${day}" -gt 31 ]]; then
+        echo "ERROR: Day out of range (01-31): ${day}" >&2
         return 1
     fi
 
@@ -136,8 +136,8 @@ validate_file_path() {
     local path="$1"
 
     # Check for directory traversal patterns
-    if [[ "$path" =~ \.\./|/\.\.$ ]]; then
-        echo "ERROR: Path contains directory traversal: $path" >&2
+    if [[ "${path}" =~ \.\./|/\.\.$ ]]; then
+        echo "ERROR: Path contains directory traversal: ${path}" >&2
         return 1
     fi
 
@@ -156,8 +156,8 @@ validate_output_filename() {
     local filename="$1"
 
     # Allow alphanumeric, underscore, dash, dot, slash (for paths)
-    if [[ ! "$filename" =~ ^[a-zA-Z0-9_./+-]+$ ]]; then
-        echo "ERROR: Invalid characters in filename: $filename" >&2
+    if [[ ! "${filename}" =~ ^[a-zA-Z0-9_./+-]+$ ]]; then
+        echo "ERROR: Invalid characters in filename: ${filename}" >&2
         echo "Allowed: letters, numbers, underscore, dash, dot, slash" >&2
         return 1
     fi
@@ -169,13 +169,13 @@ validate_output_filename() {
 validate_readable_file() {
     local file="$1"
 
-    if [ ! -f "$file" ]; then
-        echo "ERROR: File does not exist: $file" >&2
+    if [[ ! -f "${file}" ]]; then
+        echo "ERROR: File does not exist: ${file}" >&2
         return 1
     fi
 
-    if [ ! -r "$file" ]; then
-        echo "ERROR: File is not readable: $file" >&2
+    if [[ ! -r "${file}" ]]; then
+        echo "ERROR: File is not readable: ${file}" >&2
         return 1
     fi
 
@@ -186,13 +186,13 @@ validate_readable_file() {
 validate_writable_directory() {
     local dir="$1"
 
-    if [ ! -d "$dir" ]; then
-        echo "ERROR: Directory does not exist: $dir" >&2
+    if [[ ! -d "${dir}" ]]; then
+        echo "ERROR: Directory does not exist: ${dir}" >&2
         return 1
     fi
 
-    if [ ! -w "$dir" ]; then
-        echo "ERROR: Directory is not writable: $dir" >&2
+    if [[ ! -w "${dir}" ]]; then
+        echo "ERROR: Directory is not writable: ${dir}" >&2
         return 1
     fi
 
@@ -203,7 +203,7 @@ validate_writable_directory() {
 sanitize_filename() {
     local filename="$1"
     # Replace any non-alphanumeric (except _ - .) with underscore
-    echo "$filename" | tr -c '[:alnum:]_.-' '_'
+    echo "${filename}" | tr -c '[:alnum:]_.-' '_'
 }
 
 # Sanitize general input (for dates, paths, etc.)
@@ -211,7 +211,7 @@ sanitize_input() {
     local input="$1"
     # Keep only: alphanumeric, dash, slash, colon, underscore, dot (for dates/paths)
     # Remove potentially dangerous characters
-    echo "$input" | tr -cd '[:alnum:]/:_. -'
+    echo "${input}" | tr -cd '[:alnum:]/:_. -'
 }
 
 # Detect potential injection attempts
@@ -220,26 +220,26 @@ detect_injection_attempt() {
 
     # Check for common injection patterns
     # Command substitution: $(...) or `...`
-    if [[ "$input" =~ \$\( ]] || [[ "$input" =~ \` ]]; then
+    if [[ "${input}" =~ \$\( ]] || [[ "${input}" =~ \` ]]; then
         return 0  # Detected
     fi
 
     # Shell operators: ; | && || > < >> << &
     # Use case/glob instead of =~ to avoid bracket-expression portability issues
-    case "$input" in
+    case "${input}" in
         *';'*|*'|'*|*'&'*|*'>'*|*'<'*)
             return 0 ;;  # Detected
     esac
 
     # Newlines or carriage returns (potential log injection)
-    if [[ "$input" =~ $'\n' ]] || [[ "$input" =~ $'\r' ]]; then
+    if [[ "${input}" =~ $'\n' ]] || [[ "${input}" =~ $'\r' ]]; then
         return 0  # Detected
     fi
 
     # Null bytes: compare length before and after stripping NUL
     local stripped
-    stripped=$(printf '%s' "$input" | tr -d '\0')
-    if [ "${#input}" -ne "${#stripped}" ]; then
+    stripped=$(printf '%s' "${input}" | tr -d '\0')
+    if [[ "${#input}" -ne "${#stripped}" ]]; then
         return 0  # Detected
     fi
 
@@ -252,36 +252,36 @@ validate_and_sanitize_date() {
     local format="$2"  # slurm, lsf, pbs, or uge
 
     # First check for injection attempts
-    if detect_injection_attempt "$date"; then
+    if detect_injection_attempt "${date}"; then
         echo "ERROR: Potential injection attempt detected in date" >&2
         return 1
     fi
 
     # Sanitize the input
-    local clean_date=$(sanitize_input "$date")
+    local clean_date=$(sanitize_input "${date}")
 
     # Validate format-specific
-    case "$format" in
+    case "${format}" in
         slurm)
-            validate_date_slurm "$clean_date" || return 1
+            validate_date_slurm "${clean_date}" || return 1
             ;;
         lsf)
-            validate_date_lsf "$clean_date" || return 1
+            validate_date_lsf "${clean_date}" || return 1
             ;;
         pbs)
-            validate_date_pbs "$clean_date" || return 1
+            validate_date_pbs "${clean_date}" || return 1
             ;;
         uge)
-            validate_date_uge "$clean_date" || return 1
+            validate_date_uge "${clean_date}" || return 1
             ;;
         *)
-            echo "ERROR: Unknown date format: $format" >&2
+            echo "ERROR: Unknown date format: ${format}" >&2
             return 1
             ;;
     esac
 
     # Return the sanitized date
-    echo "$clean_date"
+    echo "${clean_date}"
     return 0
 }
 
@@ -290,17 +290,17 @@ validate_and_sanitize_path() {
     local path="$1"
 
     # Check for injection attempts
-    if detect_injection_attempt "$path"; then
+    if detect_injection_attempt "${path}"; then
         echo "ERROR: Potential injection attempt detected in path" >&2
         return 1
     fi
 
     # Check for directory traversal
-    if ! validate_file_path "$path"; then
+    if ! validate_file_path "${path}"; then
         return 1
     fi
 
     # Sanitize and return
-    sanitize_input "$path"
+    sanitize_input "${path}"
     return 0
 }


### PR DESCRIPTION
## Summary

Addresses the low-effort/high-value items from an audit of the 11 open issues.

### 1. Fix `PBS_ACCT_DIR` override (prerequisite bug)
`export_pbs_data.sh` told users to `export PBS_ACCT_DIR=...` in its error message but never read the variable — `ACCT_DIR` was hardcoded. Now honored as documented.

### 2. PBS end-to-end integration test (Closes #2)
Adds PBS to `tests/test_integration.bats`, completing end-to-end coverage for **all 5 schedulers** (SLURM, LSF, UGE, HTCondor, PBS). Fixture injected via `PBS_ACCT_DIR`; a no-op `qstat` mock satisfies the command-availability gate.

### 3. Run bats suite in CI
The 149-test bats suite was run locally by `run_checks.sh` but **not** by CI (`security.yml` only ran `test_exports.sh` + `security_tests.sh`). Added an `Install bats` + `Run bats Test Suite` step so the project's most comprehensive tests now guard every PR.

### 4. ShellCheck style autofix (#7, partial)
Mechanical `shellcheck -f diff` across all 22 scripts: brace-wraps variables (SC2250) and switches `[ ]`→`[[ ]]` (SC2292). **Reduces findings 950 → 86.** No logic changes. The remaining ~86 nuanced findings (SC2155, SC2059, SC2010, SC2312, etc.) are left for a follow-up on #7.

## Verification
- `bats tests/` — **149 pass** (147 existing + 2 new PBS)
- `./security_tests.sh` — **18/18 pass**
- `./test_exports.sh` — all pass
- `bash -n` syntax check clean on all 22 scripts after autofix

Note: pre-existing ruff/shellcheck `run_checks.sh` failures are unchanged by this PR and are non-blocking in CI (`continue-on-error: true`).